### PR TITLE
various mask and bounds improvements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,7 +31,7 @@ Changed (**Breaking**)
 
 Changed
 ^^^^^^^
-- `setup_mask` and `setup_bounds` both have include- and exclude polygon and min- and max elevation arguments to determine valid / boundary cells. 
+- `setup_mask` and `setup_bounds` both have a mask_fn, include_mask_fn and exclude_mask_fn polygon and min_elv and max_elv elevation arguments to determine valid / boundary cells. 
 - `setup_mask` and `setup_bounds` have a reset_mask and reset_bounds option respectively to start with a clean mask or remove previously set boundary cells.
 - `setup_mask` takes a new `drop_area` argument to drop regions of contiguous cells smaller than this maximum area threshold, useful to remove (spurious) small islands.
 - `setup_mask` takes a new `fill_area` argument to fill regions of contiguous cells below the `min_elv` or above `max_elv` threshold surrounded by cells within the valid elevation range.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,7 @@ Changed
 - `setup_river_inflow` and `setup_river_outflow` are now based on the same `workflows.river_boundary_points` method. 
    Both have a `river_upa` and `river_len` argument and the hydrography data is not required if `setup_river_hydrography` is ran beforehand.
    The model domain is also determined on-the-fly, thus it is not required to run setup_mask beforehand.
+- `setup_river_inflow` has a closed_bounds_buffer to make sure boundary cells within a radius from source points are closed.
 - `write_config` has a new `rel_path` argument that allows you to write sfincs.inp with references to model files in the root and rel_path directory.
 - Write dep file with cm accuracy. This should be sufficient but also hides differences between linux and window builds.
 - Exposed `interp_method` argument in `setup_merge_topobathy` to select interpolation method for fill NaNs.

--- a/envs/hydromt-sfincs.yml
+++ b/envs/hydromt-sfincs.yml
@@ -40,5 +40,4 @@ dependencies:
   - xarray
   - zarr
   - pip:
-    - git+https://github.com/Deltares/hydromt.git@setup_region
-    # - git+https://github.com/Deltares/hydromt_sfincs.git@setup_region
+    - git+https://github.com/Deltares/hydromt.git

--- a/examples/sfincs_coastal.ini
+++ b/examples/sfincs_coastal.ini
@@ -29,7 +29,7 @@ map_fn = None                   # mapping file. read from hydromt/data/lulc/{lul
 
 [setup_bounds]
 btype = waterlevel              # boundary type ['waterlevel', 'outflow']
-include_mask_fn = osm_coastlines  # sea polygon
+mask_fn = osm_coastlines        # sea polygon
 
 [setup_h_forcing]
 geodataset_fn = data/gtsm_locations.csv  # waterlevel gauge locations

--- a/hydromt_sfincs/plots.py
+++ b/hydromt_sfincs/plots.py
@@ -84,6 +84,7 @@ def plot_basemap(
     shaded: bool = True,
     plot_bounds: bool = True,
     plot_region: bool = False,
+    plot_geoms: bool = True,
     bmap: str = "sat",
     zoomlevel: int = 11,
     figsize: Tuple[int] = None,
@@ -109,6 +110,8 @@ def plot_basemap(
         Add waterlevel (msk=2) and open (msk=3) boundary conditions to plot.
     plot_region : bool, optional
         If True, plot region outline.
+    plot_geoms : bool, optional
+        If True, plot available geoms.        
     bmap : {'sat', 'osm'}
         background map, by default "sat"
     zoomlevel : int, optional
@@ -122,7 +125,6 @@ def plot_basemap(
         For instance: {'src': {'markersize': 30}}.
     legend_kwargs : Dict, optional
         Legend kwargs, passed to ax.legend method.
-
     Returns
     -------
     fig, axes
@@ -170,6 +172,7 @@ def plot_basemap(
             norm = colors.Normalize(vmin=vmin, vmax=vmax)
             cmap, norm = kwargs.pop("cmap", cmap), kwargs.pop("norm", norm)
             kwargs.update(norm=norm, cmap=cmap)
+
     if variable in staticmaps:
         da = staticmaps[variable].raster.mask_nodata()
         # by default colorbar on lower right & legend upper right
@@ -229,19 +232,22 @@ def plot_basemap(
         if gdf_msk3.index.size > 0:
             gdf_msk3.plot(ax=ax, zorder=3, label="outflow bnd", **geom_style["msk3"])
     # plot static geoms
-    geoms = geoms if isinstance(geoms, list) else list(staticgeoms.keys())
-    for name in geoms:
-        gdf = staticgeoms.get(name, None)
-        if gdf is None or name in ["region", "bbox"]:
-            continue
-        # copy is important to keep annotate working if repeated
-        kwargs = geom_style.get(name, {}).copy()
-        annotate = kwargs.pop("annotate", False)
-        gdf.plot(ax=ax, zorder=3, label=name, **kwargs)
-        if annotate:
-            for label, row in gdf.iterrows():
-                x, y = row.geometry.x, row.geometry.y
-                ax.annotate(label, xy=(x, y), **ann_kwargs)
+    if plot_geoms:
+
+        geoms = geoms if isinstance(geoms, list) else list(staticgeoms.keys())
+        for name in geoms:
+            gdf = staticgeoms.get(name, None)
+            if gdf is None or name in ["region", "bbox"]:
+                continue
+            # copy is important to keep annotate working if repeated
+            kwargs = geom_style.get(name, {}).copy()
+            annotate = kwargs.pop("annotate", False)
+            gdf.plot(ax=ax, zorder=3, label=name, **kwargs)
+            if annotate:
+                for label, row in gdf.iterrows():
+                    x, y = row.geometry.x, row.geometry.y
+                    ax.annotate(label, xy=(x, y), **ann_kwargs)
+
     if "region" in staticgeoms and plot_region:
         staticgeoms["region"].boundary.plot(ax=ax, ls="-", lw=0.5, color="k", zorder=2)
 

--- a/hydromt_sfincs/plots.py
+++ b/hydromt_sfincs/plots.py
@@ -111,7 +111,7 @@ def plot_basemap(
     plot_region : bool, optional
         If True, plot region outline.
     plot_geoms : bool, optional
-        If True, plot available geoms.        
+        If True, plot available geoms.
     bmap : {'sat', 'osm'}
         background map, by default "sat"
     zoomlevel : int, optional
@@ -231,9 +231,9 @@ def plot_basemap(
             gdf_msk2.plot(ax=ax, zorder=3, label="waterlevel bnd", **geom_style["msk2"])
         if gdf_msk3.index.size > 0:
             gdf_msk3.plot(ax=ax, zorder=3, label="outflow bnd", **geom_style["msk3"])
+
     # plot static geoms
     if plot_geoms:
-
         geoms = geoms if isinstance(geoms, list) else list(staticgeoms.keys())
         for name in geoms:
             gdf = staticgeoms.get(name, None)

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -372,12 +372,13 @@ class SfincsModel(Model):
 
         # read geometries
         gdf0, gdf1, gdf2 = None, None, None
+        bbox = self.region.to_crs(4326).total_bounds
         if mask_fn is not None:
-            gdf0 = self.data_catalog.get_geodataframe(mask_fn, geom=self.region)
+            gdf0 = self.data_catalog.get_geodataframe(mask_fn, bbox=bbox)
         if include_mask_fn is not None:
-            gdf1 = self.data_catalog.get_geodataframe(include_mask_fn, geom=self.region)
+            gdf1 = self.data_catalog.get_geodataframe(include_mask_fn, bbox=bbox)
         if exclude_mask_fn is not None:
-            gdf2 = self.data_catalog.get_geodataframe(exclude_mask_fn, geom=self.region)
+            gdf2 = self.data_catalog.get_geodataframe(exclude_mask_fn, bbox=bbox)
 
         # get mask
         da_mask = utils.mask_topobathy(
@@ -466,17 +467,18 @@ class SfincsModel(Model):
 
         # get mask / include / exclude geometries
         gdf0, gdf_include, gdf_exclude = None, None, None
+        bbox = self.region.to_crs(4326).total_bounds
         if mask_fn:
-            gdf0 = self.data_catalog.get_geodataframe(mask_fn, geom=self.region)
+            gdf0 = self.data_catalog.get_geodataframe(mask_fn, bbox=bbox)
             if include_buffer > 0:  # NOTE assumes model in projected CRS!
                 gdf0["geometry"] = gdf0.to_crs(self.crs).buffer(include_buffer)
         if include_mask_fn:
             gdf_include = self.data_catalog.get_geodataframe(
-                include_mask_fn, geom=self.region
+                include_mask_fn, bbox=bbox
             )
         if exclude_mask_fn:
             gdf_exclude = self.data_catalog.get_geodataframe(
-                exclude_mask_fn, geom=self.region
+                exclude_mask_fn, bbox=bbox
             )
 
         # mask values

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -319,6 +319,7 @@ class SfincsModel(Model):
         drop_area=0,
         connectivity=8,
         all_touched=True,
+        overrule_with_include=False,
         reset_mask=False,
     ):
         """Creates mask of active model cells.
@@ -383,6 +384,7 @@ class SfincsModel(Model):
             drop_area=drop_area,
             connectivity=connectivity,
             all_touched=all_touched,
+            overrule_with_include=overrule_with_include,
             logger=self.logger,
         )
 

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -1686,6 +1686,8 @@ class SfincsModel(Model):
         variable: str = "dep",
         shaded: bool = True,
         plot_bounds: bool = True,
+        plot_region: bool = False,
+        plot_geoms: bool = True,
         bmap: str = "sat",
         zoomlevel: int = 11,
         figsize: Tuple[int] = None,
@@ -1712,6 +1714,10 @@ class SfincsModel(Model):
             Add shade to variable (only for variable = 'dep'), by default True
         plot_bounds : bool, optional
             Add waterlevel (msk=2) and open (msk=3) boundary conditions to plot.
+        plot_region : bool, optional
+            If True, plot region outline.            
+        plot_geoms : bool, optional
+            If True, plot available geoms.               
         bmap : {'sat', ''}
             background map, by default "sat"
         zoomlevel : int, optional
@@ -1749,6 +1755,8 @@ class SfincsModel(Model):
             variable=variable,
             shaded=shaded,
             plot_bounds=plot_bounds,
+            plot_region=plot_region,
+            plot_geoms=plot_geoms,
             bmap=bmap,
             zoomlevel=zoomlevel,
             figsize=figsize,

--- a/hydromt_sfincs/utils.py
+++ b/hydromt_sfincs/utils.py
@@ -401,6 +401,7 @@ def write_timeseries(
 
 def mask_topobathy(
     da_elv: xr.DataArray,
+    gdf_mask: Optional[gpd.GeoDataFrame] = None,
     gdf_include: Optional[gpd.GeoDataFrame] = None,
     gdf_exclude: Optional[gpd.GeoDataFrame] = None,
     elv_min: Optional[float] = None,
@@ -409,7 +410,6 @@ def mask_topobathy(
     drop_area: float = 0,
     connectivity: int = 8,
     all_touched=True,
-    overrule_with_include=False,
     logger=logger,
 ) -> xr.DataArray:
     """Returns a boolean mask of valid (non nondata) elevation cells, optionally bounded
@@ -419,10 +419,15 @@ def mask_topobathy(
     ----------
     da_elv: xr.DataArray
         Model elevation
-    gdf_include, gdf_exclude: geopandas.GeoDataFrame
-        Geometries with areas to include/exclude from the model boundary.
+    gdf_mask: geopandas.GeoDataFrame, optional
+        Geometry describing the initial region with active model cells.
+        If not given, the initial active model cells are based on valid elevation cells.
+    gdf_include, gdf_exclude: geopandas.GeoDataFrame, optional
+        Geometries with areas to include/exclude from the active model cells.
+        Note that exclude (second last) and include (last) areas are processed after other critera,
+        i.e. `elv_min`, `elv_max` and `drop_area`, and thus overrule these criteria for active model cells.
     elv_min, elv_max : float, optional
-        Minimum and maximum elevation thresholds for boundary cells.
+        Minimum and maximum elevation thresholds for active model cells.
     fill_area : float, optional
         Maximum area [km2] of contiguous cells below `elv_min` or above `elv_max` but surrounded
         by cells within the valid elevation range to be kept as active cells, by default 10 km2.
@@ -442,9 +447,9 @@ def mask_topobathy(
         model elevation mask
     """
     da_mask = da_elv != da_elv.raster.nodata
-    da_mask2 = da_mask
-    da_mask3 = da_mask
-
+    if gdf_mask is not None:
+        _msk = da_mask.raster.geometry_mask(gdf_mask, all_touched=all_touched)
+        da_mask = np.logical_and(da_mask, _msk)
     transform, latlon = da_elv.raster.transform, da_elv.raster.crs.is_geographic
     s = None if connectivity == 4 else np.ones((3, 3), int)
     if elv_min is not None or elv_max is not None:
@@ -460,84 +465,82 @@ def mask_topobathy(
             _msk = np.logical_or(_msk, np.isin(regions, lbls[areas / 1e6 < fill_area]))
             n = int(sum(areas / 1e6 < fill_area))
             logger.debug(f"{n} gaps outside valid elevation range < {fill_area} km2.")
-        da_mask = da_mask.where(_msk, False)
-    if gdf_exclude is not None:
-        da_exclude = da_mask.raster.geometry_mask(gdf_exclude, all_touched=all_touched)
-        da_mask = da_mask.where(~da_exclude, False)
+        da_mask = np.logical_and(da_mask, _msk)
     if drop_area > 0:
         regions = ndimage.measurements.label(da_mask.values, structure=s)[0]
         lbls, areas = region_area(regions, transform, latlon)
         _msk = np.isin(regions, lbls[areas / 1e6 >= drop_area])
         n = int(sum(areas / 1e6 < drop_area))
         logger.debug(f"{n} regions < {drop_area} km2 dropped.")
-        da_mask = da_mask.where(_msk, False)
-
-    if gdf_include is not None:
-        da_include = da_mask2.raster.geometry_mask(gdf_include, all_touched=all_touched)
-        da_mask2 = da_mask2.where(da_include, False)
-
-        logger.debug(f"_msk: {_msk}")
-        logger.debug(f"da_mask: {da_mask}")
-        logger.debug(f"da_mask2: {da_mask2}")
-
-        if overrule_with_include == True:
-
-            _msk = np.logical_or(da_mask, da_mask2)
-
-            logger.debug(f"TL: Attempt to overrule da_mask with include polygon")
-
-        else:
-            _msk = da_mask
-
-        logger.debug(f"_msk: {_msk}")
-
-        da_mask3 = da_mask3.where(_msk, False)      
-        logger.debug(f"da_mask3: {da_mask3}")
-
+        da_mask = np.logical_and(da_mask, _msk)
+    if gdf_exclude is not None:
+        _msk = da_mask.raster.geometry_mask(gdf_exclude, all_touched=all_touched)
+        da_mask = np.logical_and(da_mask, ~_msk)
+    if gdf_include is not None:  # should be last to include all include areas
+        _msk = da_mask.raster.geometry_mask(gdf_include, all_touched=all_touched)
+        da_mask = np.logical_or(da_mask, _msk)  # NOTE logical OR statement
     return da_mask
 
 
 def mask_bounds(
-    da_elv: xr.DataArray,
+    da_msk: xr.DataArray,
+    da_elv: Optional[xr.DataArray] = None,
+    gdf_mask: Optional[gpd.GeoDataFrame] = None,
     gdf_include: Optional[gpd.GeoDataFrame] = None,
     gdf_exclude: Optional[gpd.GeoDataFrame] = None,
     elv_min: Optional[float] = None,
     elv_max: Optional[float] = None,
     connectivity: int = 8,
+    all_touched=False,
 ) -> xr.DataArray:
     """Returns a boolean mask model boundary cells, optionally bounded by several
     criteria. Boundary cells are defined by cells at the edge of active model domain.
 
     Parameters
     ----------
-    da_elv: xr.DataArray
-        Model elevation
+    da_msk, da_elv: xr.DataArray
+        Model mask and elevation data.
+    gdf_mask: geopandas.GeoDataFrame, optional
+        Geometry describing the initial region constraining model boundary cells.
     gdf_include, gdf_exclude: geopandas.GeoDataFrame
         Geometries with areas to include/exclude from the model boundary.
+        Note that exclude (second last) and include (last) areas are processed after other critera,
+        i.e. `elv_min`, `elv_max`, and thus overrule these criteria for model boundary cells.
     elv_min, elv_max : float, optional
         Minimum and maximum elevation thresholds for boundary cells.
     connectivity: {4, 8}
         The connectivity used to detect the model edge, if 4 only horizontal and vertical
         connections are used, if 8 (default) also diagonal connections.
+    all_touched: bool, optional
+        if True (default) include (or exclude) a cell in the mask if it touches any of the
+        include (or exclude) geometries. If False, include a cell only if its center is
+        within one of the shapes, or if it is selected by Bresenham's line algorithm.
 
     Returns
     -------
     bounds: xr.DataArray
         Boolean mask of model boundary cells.
     """
+    assert (
+        elv_min is None and elv_max is None
+    ) or da_elv is not None, "da_elv required"
     s = None if connectivity == 4 else np.ones((3, 3), int)
-    da_mask = da_elv != da_elv.raster.nodata
-    bounds = np.logical_xor(da_mask, ndimage.binary_erosion(da_mask, structure=s))
-    if gdf_include is not None:
-        da_include = da_mask.raster.geometry_mask(gdf_include)
-        bounds = bounds.where(da_include, False)
-    if gdf_exclude is not None:
-        da_exclude = da_mask.raster.geometry_mask(gdf_exclude)
-        bounds = bounds.where(~da_exclude, False)
+    da_mask = da_msk != da_msk.raster.nodata
+    bounds0 = np.logical_xor(da_mask, ndimage.binary_erosion(da_mask, structure=s))
+    bounds = bounds0.copy()
+    if gdf_mask is not None:
+        _msk = da_mask.raster.geometry_mask(gdf_mask, all_touched=all_touched)
+        bounds = np.logical_and(bounds, _msk)
     if elv_min is not None:
-        bounds = bounds.where(da_elv >= elv_min, False)
+        bounds = np.logical_and(bounds, da_elv >= elv_min)
     if elv_max is not None:
-        bounds = bounds.where(da_elv <= elv_max, False)
+        bounds = np.logical_and(bounds, da_elv <= elv_max)
+    if gdf_exclude is not None:
+        da_exclude = da_mask.raster.geometry_mask(gdf_exclude, all_touched=all_touched)
+        bounds = np.logical_and(bounds, ~da_exclude)
+    if gdf_include is not None:
+        da_include = da_mask.raster.geometry_mask(gdf_include, all_touched=all_touched)
+        bounds = np.logical_or(bounds, np.logical_and(bounds0, da_include))
     return bounds
 
 

--- a/hydromt_sfincs/utils.py
+++ b/hydromt_sfincs/utils.py
@@ -453,7 +453,7 @@ def mask_topobathy(
             _msk = da_mask.raster.geometry_mask(gdf_mask, all_touched=all_touched)
             da_mask = np.logical_and(da_mask, _msk)
         except:
-            logger.debug(f"No mask cells found within mask polygon!")        
+            logger.debug(f"No mask cells found within mask polygon!")
     transform, latlon = da_elv.raster.transform, da_elv.raster.crs.is_geographic
     s = None if connectivity == 4 else np.ones((3, 3), int)
     if elv_min is not None or elv_max is not None:


### PR DESCRIPTION
- distinguish between `mask_fn` which provides a starting point for active / boundary cells and `include_mask_fn` and `exclude_mask_fn` which overrides any previous criteria in both `setup_bounds` and `setup_mask` methods.
- `setup_river_inflow` has a closed_bounds_buffer to make sure boundary cells within a radius from source points are closed.
- add some new switches in `plot_basemaps`