### PR TITLE
fix #66

### DIFF
--- a/hydromt_sfincs/utils.py
+++ b/hydromt_sfincs/utils.py
@@ -759,7 +759,7 @@ def read_sfincs_map_results(
     dvars = list(ds_map.data_vars.keys())
     edge_dims = [var for var in dvars if (var.endswith("_x") or var.endswith("_y"))]
     ds_map = ds_map.set_coords(["x", "y"] + edge_dims)
-    crs = ds_map["crs"].item() if ds_map["crs"].item() != 0 else crs
+    crs = ds_map["crs"].item() if ds_map["crs"].item() > 0 else crs
 
     if ds_map["inp"].attrs.get("rotation") != 0:
         logger.warning("Cannot parse rotated maps. Skip reading sfincs.map.nc")


### PR DESCRIPTION
Small bug in CRS. Sometimes, a NaN CRS is read as lowest (negative) INT32 number. This is now captured by ensuring that only if an EPSG code > 0 is found, it'll be interpreted.