### PR TITLE
fix reading relative paths in inp file

### DIFF
--- a/hydromt_sfincs/sfincs_input.py
+++ b/hydromt_sfincs/sfincs_input.py
@@ -124,7 +124,7 @@ class SfincsInput:
             else:
                 try:
                     val = literal_eval(val)
-                except ValueError:  # normal string
+                except Exception:  # normal string
                     pass
             if name == "crs":
                 name = "epsg"


### PR DESCRIPTION
For relative paths, e.g., `../sfincs.dep` the except statement for string values did not work as a SyntaxError was raised. 