### PR TITLE
assigned proper nodata value to da_man when constant values applied

### DIFF
--- a/hydromt_sfincs/subgrid.py
+++ b/hydromt_sfincs/subgrid.py
@@ -450,6 +450,7 @@ class SubgridTableRegular:
                         da_man = da_man.where(~np.isnan(da_man), da_man0)
                 else:
                     da_man = xr.where(da_dep >= rgh_lev_land, manning_land, manning_sea)
+                    da_man.raster.set_nodata(np.nan)
                 # mask values of inactive cells
                 da_man = da_man.where(da_mask_sbg > 0, da_man.raster.nodata)
                 check_nans = np.all(~np.isnan(da_man.values[da_mask_sbg > 0]))


### PR DESCRIPTION
When constant values are applied (so datasets_rgh left empty) for manning in SfincsModel.setup_subgrid, the nodata value of da_man was "None", causing errors in the masking of inactive cells afterwards.

By explicitly setting the nodata value to np.nan, this problem is solved. 