### PR TITLE
adding argument to provide high resolut dem to determine structure height

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ New
 - Added the option to use landuse/landcover data combined with a reclass table to `SfincsModel.setup_constant_infiltration`.  PR #103
 - Enabled to provide locations only (so no timeseries) for `SfincsModel.setup_waterlevel_forcing` and `SfincsModel.setup_discharge_forcing` PR #104
 - New optional buffer argument in  `SfincsModel.setup_discharge_forcing` to select gauges around boundary only. PR #104
+- New functionality within `SfincsModel.setup_structures` to use high resolution dem for weir elevation
 
 Changed
 -------

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -1381,16 +1381,21 @@ class SfincsModel(GridModel):
                 res = elv.raster.res[0]
                 if elv.raster.crs.is_geographic:
                     res = res * 111111.0
-                window_size = np.ceil(buffer / res)
+                window_size = int(np.ceil(buffer / res))
             else:
                 window_size = 0
 
             structs_out = []
             for s in structs:
                 pnts = gpd.points_from_xy(x=s["x"], y=s["y"])
-                zb = elv.raster.sample(
+                zb_array = elv.raster.sample(
                     gpd.GeoDataFrame(geometry=pnts, crs=self.crs), wdw=window_size
                 )
+                if buffer is not None:
+                    zb = zb_array.max(axis=1)
+                else:
+                    zb = zb_array
+
                 if dz is not None:
                     s["z"] = zb.values + float(dz)
                 else:

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -1343,10 +1343,10 @@ class SfincsModel(GridModel):
         stype : {'thd', 'weir'}
             Structure type.
         dep : str, Path, xr.DataArray, optional
-            Path, data source name, or xarray raster object ('elevtn') describing the depth in an 
-            alternative resolution which is used for sampling the weir. 
+            Path, data source name, or xarray raster object ('elevtn') describing the depth in an
+            alternative resolution which is used for sampling the weir.
         buffer : float, optional
-            If provided, describes the distance from the centerline to the foot of the structure. 
+            If provided, describes the distance from the centerline to the foot of the structure.
             This distance is supplied to the raster.sample as the window (wdw).
         merge : bool, optional
             If True, merge with existing'stype' structures, by default True.
@@ -1409,8 +1409,6 @@ class SfincsModel(GridModel):
         # set structures
         self.set_geoms(gdf, stype)
         self.set_config(f"{stype}file", f"sfincs.{stype}")
-
-    
 
     def setup_drainage_structures(
         self,

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -1320,6 +1320,8 @@ class SfincsModel(GridModel):
         self,
         structures: Union[str, Path, gpd.GeoDataFrame],
         stype: str,
+        dep: Union[str, Path, xr.DataArray] = None,
+        buffer: float = None,
         dz: float = None,
         merge: bool = True,
         **kwargs,
@@ -1340,6 +1342,12 @@ class SfincsModel(GridModel):
             "par1" defaults to 0.6 if gdf has no "par1" column.
         stype : {'thd', 'weir'}
             Structure type.
+        dep : str, Path, xr.DataArray, optional
+            Path, data source name, or xarray raster object ('elevtn') describing the depth in an 
+            alternative resolution which is used for sampling the weir. 
+        buffer : float, optional
+            If provided, describes the distance from the centerline to the foot of the structure. 
+            This distance is supplied to the raster.sample as the window (wdw).
         merge : bool, optional
             If True, merge with existing'stype' structures, by default True.
         dz: float, optional
@@ -1363,13 +1371,30 @@ class SfincsModel(GridModel):
 
         structs = utils.gdf2linestring(gdf)  # check if it parsed correct
         # sample zb values from dep file and set z = zb + dz
-        if stype == "weir" and dz is not None:
-            elv = self.grid["dep"]
+        if stype == "weir" and (dep is not None or dz is not None):
+            if dep is not None:
+                elv = self.data_catalog.get_rasterdataset(dep)
+            else:
+                elv = self.grid["dep"]
+
+            if buffer is not None:
+                res = elv.raster.res[0]
+                if elv.raster.crs.is_geographic:
+                    res = res * 111111.0
+                window_size = np.ceil(buffer / res)
+            else:
+                window_size = 0
+
             structs_out = []
             for s in structs:
                 pnts = gpd.points_from_xy(x=s["x"], y=s["y"])
-                zb = elv.raster.sample(gpd.GeoDataFrame(geometry=pnts, crs=self.crs))
-                s["z"] = zb.values + float(dz)
+                zb = elv.raster.sample(
+                    gpd.GeoDataFrame(geometry=pnts, crs=self.crs), wdw=window_size
+                )
+                if dz is not None:
+                    s["z"] = zb.values + float(dz)
+                else:
+                    s["z"] = zb.values
                 structs_out.append(s)
             gdf = utils.linestring2gdf(structs_out, crs=self.crs)
         # Else function if you define elevation of weir
@@ -1384,6 +1409,8 @@ class SfincsModel(GridModel):
         # set structures
         self.set_geoms(gdf, stype)
         self.set_config(f"{stype}file", f"sfincs.{stype}")
+
+    
 
     def setup_drainage_structures(
         self,

--- a/hydromt_sfincs/utils.py
+++ b/hydromt_sfincs/utils.py
@@ -424,9 +424,9 @@ def gdf2linestring(gdf: gpd.GeoDataFrame) -> List[Dict]:
         feat = item.drop("geometry").dropna().to_dict()
         # check geom
         line = item.geometry
-        if line.type == "MultiLineString" and len(line.geoms) == 1:
+        if line.geom_type == "MultiLineString" and len(line.geoms) == 1:
             line = line.geoms[0]
-        if line.type != "LineString":
+        if line.geom_type != "LineString":
             raise ValueError("Invalid geometry type, only LineString is accepted.")
         xyz = tuple(zip(*line.coords[:]))
         feat["x"], feat["y"] = list(xyz[0]), list(xyz[1])

--- a/tests/test_1model_class.py
+++ b/tests/test_1model_class.py
@@ -136,6 +136,9 @@ def test_structs(tmpdir):
     assert "weirfile" in mod.config
     mod.write_geoms()
     assert isfile(join(mod.root, "sfincs.weir"))
+    # test with buffer
+    mod.setup_structures(fn_thd_gis, stype="weir", buffer=5, dep="dep", merge=False)
+    assert len(mod.geoms["weir"].index) == 2
 
 
 def test_drainage_structures(tmpdir):


### PR DESCRIPTION
 ## Issue addressed

Fixes #106, Add dep for...

## Explanation

The functionality of the setup_structures function has been enhanced. By allowing for the description of attribute "dep", a higher resolution DEM file can be used to determine the weir height. 

Next to that, an attribute "buffer" is added to account for the width of the weir segment. This buffer is used a window (wdw) in the raster.sample() function.

## Checklist 

- [ ] Change to setup_structures() code 
- [ ]  Updated changelog.rst if needed
- [ ] Updated documentation if needed

## Additional Notes (Optional)
