### PR TITLE
Fix replacing the mask values with one (due to dilating) by making a …

### DIFF
--- a/hydromt_sfincs/subgrid.py
+++ b/hydromt_sfincs/subgrid.py
@@ -369,11 +369,9 @@ class SubgridTableRegular:
                 )
 
                 # calculate transform and shape of block at cell and subgrid level
-                da_mask_block = (
-                    da_mask.isel({x_dim: slice(bm0, bm1), y_dim: slice(bn0, bn1)})
-                    .copy()
-                    .load()
-                )
+                # copy da_mask block to avoid accidently changing da_mask
+                slice_block = {x_dim: slice(bm0, bm1), y_dim: slice(bn0, bn1)}
+                da_mask_block = da_mask.isel(slice_block).copy().load()
                 check_block = np.all([s > 1 for s in da_mask_block.shape])
                 assert check_block, f"unexpected block shape {da_mask_block.shape}"
                 nactive = int(np.sum(da_mask_block > 0))

--- a/hydromt_sfincs/subgrid.py
+++ b/hydromt_sfincs/subgrid.py
@@ -371,7 +371,7 @@ class SubgridTableRegular:
                 # calculate transform and shape of block at cell and subgrid level
                 da_mask_block = da_mask.isel(
                     {x_dim: slice(bm0, bm1), y_dim: slice(bn0, bn1)}
-                ).load()
+                ).copy().load()
                 check_block = np.all([s > 1 for s in da_mask_block.shape])
                 assert check_block, f"unexpected block shape {da_mask_block.shape}"
                 nactive = int(np.sum(da_mask_block > 0))

--- a/hydromt_sfincs/subgrid.py
+++ b/hydromt_sfincs/subgrid.py
@@ -369,9 +369,11 @@ class SubgridTableRegular:
                 )
 
                 # calculate transform and shape of block at cell and subgrid level
-                da_mask_block = da_mask.isel(
-                    {x_dim: slice(bm0, bm1), y_dim: slice(bn0, bn1)}
-                ).copy().load()
+                da_mask_block = (
+                    da_mask.isel({x_dim: slice(bm0, bm1), y_dim: slice(bn0, bn1)})
+                    .copy()
+                    .load()
+                )
                 check_block = np.all([s > 1 for s in da_mask_block.shape])
                 assert check_block, f"unexpected block shape {da_mask_block.shape}"
                 nactive = int(np.sum(da_mask_block > 0))


### PR DESCRIPTION
 ## Issue addressed

@taiwoogunwumi found out that the mask seems to be resetted after setup_subgrid

## Explanation

While generating the subgrid with setup_subgrid, ndimage.binary_dilation not only replaces the values of da_mask_block but also the ones of da_mask. Therefore, setup_subgrid basically resets the boundary mask cells. This is not desired.

By making a copy, the problem seems te be solved.

## Additional Notes (Optional)
