### PR TITLE
don't clip geotiffs to region, but only mask inactive cells

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Fixed
 -----
 - writing COG files in `SfincsModel.setup_subgrid` (the COG driver settings were wrong) PR #117
 - a constant offset in the `datasets_dep` argument to `SfincsModel.setup_subgrid` and `SfincsModel.setup_dep` was ignored PR #119
+- mismatch between gis data and the model grid causing issues while reading the model PR #128
 
 Deprecated
 ----------

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -3187,7 +3187,7 @@ class SfincsModel(GridModel):
                         )
                         continue
                 # only write active cells to gis files
-                da = da.raster.clip_geom(self.region, mask=True).raster.mask_nodata()
+                da = da.where(self.mask>0, da.raster.nodata).raster.mask_nodata()
                 if da.raster.res[1] > 0:  # make sure orientation is N->S
                     da = da.raster.flipud()
                 da.raster.to_raster(

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -3187,7 +3187,7 @@ class SfincsModel(GridModel):
                         )
                         continue
                 # only write active cells to gis files
-                da = da.where(self.mask>0, da.raster.nodata).raster.mask_nodata()
+                da = da.where(self.mask > 0, da.raster.nodata).raster.mask_nodata()
                 if da.raster.res[1] > 0:  # make sure orientation is N->S
                     da = da.raster.flipud()
                 da.raster.to_raster(


### PR DESCRIPTION
Because of clipping of the rasterdata to the region while writing away the geotiffs to the gis-folder, there was a mismatch between the size of the gis-data and the model grid data. This may cause issues while reading the model.

This problem somehow only arised for rotated models, and also only when the gis-data is used, which is the case when the depfile is not written because of the presence of the subgridfile.