### PR TITLE
align grid with resolution

### DIFF
--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -259,6 +259,7 @@ class SfincsModel(GridModel):
             based on a (sub)(inter)basins without a 'bounds' argument.
         align : bool, optional
             If True (default), align target transform to resolution.
+            Note that this has only been implemented for non-rotated grids.
         dec_origin : int, optional
             number of decimals to round the origin coordinates, by default 0
         dec_rotation : int, optional

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -225,6 +225,7 @@ class SfincsModel(GridModel):
         rotated: bool = False,
         hydrography_fn: str = None,
         basin_index_fn: str = None,
+        align: bool = False,
         dec_origin: int = 0,
         dec_rotation: int = 3,
     ):
@@ -256,6 +257,8 @@ class SfincsModel(GridModel):
             Name of data source with basin (bounding box) geometries associated with
             the 'basins' layer of `hydrography_fn`. Only required if the `region` is
             based on a (sub)(inter)basins without a 'bounds' argument.
+        align : bool, optional
+            If True (default), align target transform to resolution.
         dec_origin : int, optional
             number of decimals to round the origin coordinates, by default 0
         dec_rotation : int, optional
@@ -287,7 +290,11 @@ class SfincsModel(GridModel):
             )
         else:
             x0, y0, x1, y1 = self.geoms["region"].total_bounds
-            x0, y0 = round(x0, dec_origin), round(y0, dec_origin)
+            if align:
+                x0 = round(x0 / res) * res
+                y0 = round(y0 / res) * res
+            else:
+                x0, y0 = round(x0, dec_origin), round(y0, dec_origin)
             mmax = int(np.ceil((x1 - x0) / res))
             nmax = int(np.ceil((y1 - y0) / res))
             rot = 0


### PR DESCRIPTION
For certain projects, it is desirable to align the SFINCS grid with already existing grids. This can be easily achieved by rounding of the origin of the grid.

The proposed changes are in line with already existing functionality in HydroMT-core [(see here)](https://github.com/Deltares/hydromt/blob/31d69df14e5e42e0948f533e82cbabb269f3faee/hydromt/models/model_grid.py#L458) 

At the moment HydroMT-SFINCS makes distinction between setup_grid and setup_grid_from_region (the latter is in line with the setup_grid from the core), which makes it hard to use the core functionality. I propose to have it temporary fixed like this and find a more integral solution in the future to prevent double maintenance work.