### PR TITLE
core version is fixed in pyrpoject.toml so not needed in yamls

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - descartes # to run examples
   - ffmpeg  # to run examples (animation)
   # - git
-  - hydromt>=0.8.0
   - hydromt_sfincs>=1.0
   - jupyterlab # to run examples
   - matplotlib # to run examples

--- a/envs/hydromt-sfincs-dev.yml
+++ b/envs/hydromt-sfincs-dev.yml
@@ -13,7 +13,6 @@ dependencies:
   - ffmpeg  # to run examples (animation)
   - flit>=3.4
   - geopandas>=0.8
-  - hydromt>=0.8.0
   - jupyterlab  # to run examples
   - matplotlib # to run examples
   - nbsphinx  # docs

--- a/envs/hydromt-sfincs-min.yml
+++ b/envs/hydromt-sfincs-min.yml
@@ -8,7 +8,6 @@ channels:
 dependencies:
   - flit>=3.4
   - geopandas>=0.8
-  - hydromt>=0.8.0
   - numba
   - numpy
   - pandas


### PR DESCRIPTION
It seemed that since the new core release (0.9.0) quite some tests were failing...

We tried to fix the hydromt version in the pyproject.toml, but I expect that this is overruled by defining versions of hydromt in the environment.ymls as well.