### PR TITLE
fixed masking of dep and man datasets when providing mask

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changed
 
 Fixed
 -----
+- fixed masking of elevation and manning datasets when providing mask attribute
 
 Deprecated
 ----------

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -3503,7 +3503,7 @@ class SfincsModel(GridModel):
             # read geodataframes describing valid areas
             if "mask" in dataset:
                 gdf_valid = self.data_catalog.get_geodataframe(
-                    path_or_key=dataset.get("mask"),
+                    dataset.get("mask"),
                     bbox=self.mask.raster.transform_bounds(4326),
                 )
                 dd.update({"gdf_valid": gdf_valid})
@@ -3576,7 +3576,7 @@ class SfincsModel(GridModel):
             # read geodataframes describing valid areas
             if "mask" in dataset:
                 gdf_valid = self.data_catalog.get_geodataframe(
-                    path_or_key=dataset.get("mask"),
+                    dataset.get("mask"),
                     bbox=self.mask.raster.transform_bounds(4326),
                 )
                 dd.update({"gdf_valid": gdf_valid})


### PR DESCRIPTION
## Issue addressed
No issue created, but the "mask" attribute in datasets_dep or datasets_rgh wasn't parsed correctly after changes in the core (very old changes though). Apparently this function was never used.

## Explanation
Updated the code accordingly and now masking of the datasets works again!

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [x] Updated changelog.rst if needed

