### PR TITLE
fix filter timeseries in setup_x_forcing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Added
 Changed
 -------
 - support for HydroMT core v0.9
+- support for filtering forcing data from timeseries and locations based on model region (#103)
 
 Fixed
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Added
 Changed
 -------
 - support for HydroMT core v0.9
-- support for filtering forcing data from timeseries and locations based on model region (#103)
+- support for filtering forcing data from timeseries and locations based on model region (#162)
 
 Fixed
 -----

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -1853,6 +1853,10 @@ class SfincsModel(GridModel):
             ).to_crs(self.crs)
             if "index" in gdf_locs.columns:
                 gdf_locs = gdf_locs.set_index("index")
+            # filter df_ts timeseries based on gdf_locs index
+            # this allows to use a subset of the locations in the timeseries
+            if df_ts is not None and np.isin(gdf_locs.index, df_ts.columns).all():
+                df_ts = df_ts.reindex(gdf_locs.index, axis=1, fill_value=0)
         elif gdf_locs is None and "bzs" in self.forcing:
             gdf_locs = self.forcing["bzs"].vector.to_gdf()
         elif gdf_locs is None:
@@ -2002,6 +2006,10 @@ class SfincsModel(GridModel):
             ).to_crs(self.crs)
             if "index" in gdf_locs.columns:
                 gdf_locs = gdf_locs.set_index("index")
+            # filter df_ts timeseries based on gdf_locs index
+            # this allows to use a subset of the locations in the timeseries
+            if df_ts is not None and np.isin(gdf_locs.index, df_ts.columns).all():
+                df_ts = df_ts.reindex(gdf_locs.index, axis=1, fill_value=0)
         elif gdf_locs is None and "dis" in self.forcing:
             gdf_locs = self.forcing["dis"].vector.to_gdf()
         elif gdf_locs is None:


### PR DESCRIPTION
## Issue addressed
Fixes filtering of timeseries in case you have a large dataset in separate files for the timeseries and locations (rather than one geodataset). If the locations are filtered based on the model region a subset of the locations and all timeseries are passed to the `set_1d_forcing` method raising an error that the indices do not match.

## Explanation
Add a filtering step after reading the location in `setup_waterlevel_forcing` and `setup_discharge_forcing`

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
