### PR TITLE
Docstring for setup_grid_from_region bbox option needs to be in WG84

### DIFF
--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -239,8 +239,11 @@ class SfincsModel(GridModel):
             * {'bbox': [xmin, ymin, xmax, ymax]}
             * {'geom': 'path/to/polygon_geometry'}
 
+            For the ``bbox`` option the coordinates for the bottom-left and top-right corners
+            need to be provided in WG84/EPSG:4326.
+            
             For a complete overview of all region options,
-            see :py:function:~hydromt.workflows.basin_mask.parse_region
+            see :py:function:: hydromt.workflows.basin_mask.parse_region
         res : float, optional
             grid resolution, by default 100 m
         crs : Union[str, int], optional

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -239,11 +239,10 @@ class SfincsModel(GridModel):
             * {'bbox': [xmin, ymin, xmax, ymax]}
             * {'geom': 'path/to/polygon_geometry'}
 
-            For the ``bbox`` option the coordinates for the bottom-left and top-right corners
-            need to be provided in WG84/EPSG:4326.
-            
+            Note: For the 'bbox' option the coordinates need to be provided in WG84/EPSG:4326.
+
             For a complete overview of all region options,
-            see :py:function:: hydromt.workflows.basin_mask.parse_region
+            see :py:func:`hydromt.workflows.basin_mask.parse_region`
         res : float, optional
             grid resolution, by default 100 m
         crs : Union[str, int], optional
@@ -334,7 +333,7 @@ class SfincsModel(GridModel):
         datasets_dep : List[dict]
             List of dictionaries with topobathy data, each containing a dataset name or Path (elevtn) and optional merge arguments e.g.:
             [{'elevtn': merit_hydro, 'zmin': 0.01}, {'elevtn': gebco, 'offset': 0, 'merge_method': 'first', 'reproj_method': 'bilinear'}]
-            For a complete overview of all merge options, see :py:function:~hydromt.workflows.merge_multi_dataarrays
+            For a complete overview of all merge options, see :py:func:`hydromt.workflows.merge_multi_dataarrays`
         buffer_cells : int, optional
             Number of cells between datasets to ensure smooth transition of bed levels, by default 0
         interp_method : str, optional
@@ -644,7 +643,7 @@ class SfincsModel(GridModel):
             or xarray raster object ('elevtn').
             Optional merge arguments include: 'zmin', 'zmax', 'mask', 'offset', 'reproj_method',
             and 'merge_method', see example below. For a complete overview of all merge options,
-            see :py:function:~hydromt.workflows.merge_multi_dataarrays
+            see :py:func:`hydromt.workflows.merge_multi_dataarrays`
 
             ::
 
@@ -685,7 +684,7 @@ class SfincsModel(GridModel):
               segment_length [m] (default 500m) and riv_bank_q [0-1] (default 0.5)
               which used to estimate the river bank height in case river depth is provided.
 
-            For more info see :py:function:~hydromt.workflows.bathymetry.burn_river_rect
+            For more info see :py:func:`hydromt.workflows.bathymetry.burn_river_rect`
 
            ::
 
@@ -2231,7 +2230,7 @@ class SfincsModel(GridModel):
 
         Parameters
         ----------
-        timeseries, str, Path
+        timeseries: str, Path
             Path to tabulated timeseries csv file with time index in first column
             and location IDs in the first row,
             see :py:meth:`hydromt.open_timeseries_from_table`, for details.
@@ -2456,7 +2455,7 @@ class SfincsModel(GridModel):
         datasets_dep : List[dict]
             List of dictionaries with topobathy data, each containing a dataset name or Path (elevtn) and optional merge arguments e.g.:
             [{'elevtn': merit_hydro, 'zmin': 0.01}, {'elevtn': gebco, 'offset': 0, 'merge_method': 'first', reproj_method: 'bilinear'}]
-            For a complete overview of all merge options, see :py:function:~hydromt.workflows.merge_multi_dataarrays
+            For a complete overview of all merge options, see :py:func:`~hydromt.workflows.merge_multi_dataarrays`
             Note that subgrid/dep_subgrid.tif is automatically used if present and datasets_dep is left empty.
         zoom_range : Union[int, List[int]], optional
             Range of zoom levels for which tiles are created, by default [0,13]


### PR DESCRIPTION
Closes #182 

I just added a short note.
> For the ``bbox`` option the coordinates for the bottom-left and top-right corners
>           need to be provided in WG84/EPSG:4326.

I also noticed that there seems to be a formatting error https://deltares.github.io/hydromt_sfincs/latest/_generated/hydromt_sfincs.SfincsModel.setup_grid_from_region.html
```
For a complete overview of all region options, see :py:function:~hydromt.workflows.basin_mask.parse_region
```
but I am not really familiar with the Sphinx syntax, not sure whether it is supposed to link somewhere or whether `~` should have been `:` which is what I went for.