### PR TITLE
fix tests subgrid rivers; order of geodataframe provided by hydromt c…

### DIFF
--- a/tests/test_1model_class.py
+++ b/tests/test_1model_class.py
@@ -107,9 +107,13 @@ def test_subgrid_rivers(mod):
     gdf_riv = mod.data_catalog.get_geodataframe(
         "rivers_lin2019_v1", geom=mod.region, buffer=1e3
     )
+
+    # create dummy depths for the river based on the width
     rivdph = gdf_riv["rivwth"].values / 100
-    rivdph[-1] = np.nan
     gdf_riv["rivdph"] = rivdph
+
+    # set the depth of the river with "COMID": 21002062 to nan
+    gdf_riv.loc[gdf_riv["COMID"] == 21002062, "rivdph"] = np.nan
 
     sbg_org = mod.subgrid.copy()
 


### PR DESCRIPTION
For testing the burning in of the rivers in the subgrid, we used a "crop" of the lin2019 dataset. We added a dep attribute to this geodataframe, and set the dep of the last row to np.nan (to also check applying an overall depth). 

Somehow, the order of the geodataframe given back by data_catalog.get_geodataframe changed, and therefore also the river where we set the depth to np.nan. This resulted in a significantly different subgrid for the test. 

## Issue addressed
Rather than failing tests, there was no issue.

## Explanation
Instead of taking the last row of the geodataframe, we now change the row with a certain COMID, to ensure that even when the order of the rows change, we always change the same row/river.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
