### PR TITLE
Update plots.py

### DIFF
--- a/hydromt_sfincs/plots.py
+++ b/hydromt_sfincs/plots.py
@@ -258,8 +258,8 @@ def plot_basemap(
             dx, dy = da.raster.res
             _rgb = ls.shade(
                 da.fillna(0).values,
-                norm=kwargs["norm"],
-                cmap=kwargs["cmap"],
+                norm=kwargs0["norm"],
+                cmap=kwargs0["cmap"],
                 blend_mode="soft",
                 dx=dx,
                 dy=dy,


### PR DESCRIPTION
When shaded and no rotation, `kwargs` is still used instead of `kwargs0`

## Issue addressed
Fixes No known issue

## Explanation
Replace `kwargs` with `kwargs0` 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
No
