### PR TITLE
move inflow points to confluence if within buffer from model boundary

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ Added
 Changed
 -------
 - improved subgrid tables are saved as NetCDF (#160)
+- In `SfincsModel.setup_river_inflow`, in case of a confluence within a user-defined buffer of the
+  model boundary the confluence rather than both tributaries is selected as inflow point. (#202)
 
 Fixed
 -----

--- a/hydromt_sfincs/workflows/flwdir.py
+++ b/hydromt_sfincs/workflows/flwdir.py
@@ -82,7 +82,7 @@ def river_source_points(
     gdf_riv: gpd.GeoDataFrame,
     gdf_mask: gpd.GeoDataFrame,
     src_type: str = "inflow",
-    buffer: float = 100,
+    buffer: float = 200,
     river_upa: float = 10,
     river_len: float = 1e3,
     da_uparea: xr.DataArray = None,
@@ -109,7 +109,8 @@ def river_source_points(
         If 'outflow', return points where the river flows out of the model domain.
         If 'headwater', return all headwater (including inflow) points within the model domain.
     buffer: float, optional
-        Buffer around gdf_mask to select river source points, by default 100 m.
+        Buffer around gdf_mask to select river source points, by default 200 m.
+        Inflow points are moved to a downstream confluence if within the buffer.
     river_upa : float, optional
         Minimum upstream area threshold for rivers [km2], by default 10.0
     river_len: float, optional
@@ -143,6 +144,11 @@ def river_source_points(
 
     # clip river to model gdf_mask
     gdf_riv = gdf_riv.to_crs(gdf_mask.crs).clip(gdf_mask.unary_union)
+    # keep only lines
+    gdf_riv = gdf_riv[
+        [t.endswith("LineString") for t in gdf_riv.geom_type]
+    ].reset_index(drop=True)
+
     # filter river network based on uparea and length
     if "uparea" in gdf_riv.columns:
         gdf_riv = gdf_riv[gdf_riv["uparea"] >= river_upa]
@@ -154,6 +160,10 @@ def river_source_points(
         )
         return gpd.GeoDataFrame()
 
+    # remove lines that fully are within the buffer of the mask boundary
+    bnd = gdf_mask.boundary.buffer(buffer).unary_union
+    gdf_riv = gdf_riv[~gdf_riv.within(bnd)]
+
     # get source points 1m before the start/end of the river
     # a positive dx results in a point near the start of the line (inflow)
     # a negative dx results in a point near the end of the line (outflow)
@@ -164,7 +174,7 @@ def river_source_points(
     gdf_ds["riv_idx"] = gdf_riv.index
 
     # get points that do not intersect with up/downstream end of other river segments
-    # use a small buffer of 5m around these points to account for dx and avoid issues with inprecise river geometries
+    # use a small buffer of 5m around these points to account for dx and avoid issues with imprecise river geometries
     if src_type in ["inflow", "headwater"]:
         pnts_ds = gdf_ds.buffer(5).unary_union
         gdf_pnt = gdf_up[~gdf_up.intersects(pnts_ds)].reset_index(drop=True)
@@ -174,7 +184,6 @@ def river_source_points(
 
     # get buffer around gdf_mask, in- and outflow points should be within this buffer
     if src_type in ["inflow", "outflow"]:
-        bnd = gdf_mask.boundary.buffer(buffer).unary_union
         gdf_pnt = gdf_pnt[gdf_pnt.intersects(bnd)].reset_index(drop=True)
 
     # log numer of source points

--- a/hydromt_sfincs/workflows/flwdir.py
+++ b/hydromt_sfincs/workflows/flwdir.py
@@ -1,4 +1,5 @@
 """Flow direction and river network workflows for SFINCS models."""
+
 import logging
 from typing import Tuple
 
@@ -169,9 +170,7 @@ def river_source_points(
     # a negative dx results in a point near the end of the line (outflow)
     dx = -1 if reverse_river_geom else 1
     gdf_up = gdf_riv.interpolate(dx).to_frame("geometry")
-    gdf_up["riv_idx"] = gdf_riv.index
     gdf_ds = gdf_riv.interpolate(-dx).to_frame("geometry")
-    gdf_ds["riv_idx"] = gdf_riv.index
 
     # get points that do not intersect with up/downstream end of other river segments
     # use a small buffer of 5m around these points to account for dx and avoid issues with imprecise river geometries

--- a/tests/data/sfincs_test.yml
+++ b/tests/data/sfincs_test.yml
@@ -56,6 +56,7 @@ setup_drainage_structures:
 
 setup_river_inflow:
   hydrography: merit_hydro
+  buffer: 100
   river_upa: 10
   river_len: 1000
   keep_rivers_geom: True

--- a/tests/test_flwdir.py
+++ b/tests/test_flwdir.py
@@ -39,20 +39,20 @@ def test_river_source_points(hydrography, data_catalog):
     assert gdf_src.index.size == 6
     gdf_src = river_source_points(src_type="outflow", da_uparea=da_uparea, **kwargs)
     assert gdf_src.index.size == 1
-    assert np.isin(["geometry", "riv_idx", "uparea"], gdf_src.columns).all()
+    assert np.isin(["geometry", "uparea"], gdf_src.columns).all()
+    np.allclose(gdf_src.geometry[0].coords[:], [(322650.3, 5044385.7)])
 
     # test reverse oriented line
     gdf_riv = data_catalog.get_geodataframe("rivers_lin2019_v1")
     kwargs = dict(gdf_riv=gdf_riv, gdf_mask=gdf_mask, reverse_river_geom=True)
     gdf_src = river_source_points(src_type="inflow", **kwargs)
     assert gdf_src.index.size == 1  # this data only one river
-    assert gdf_src["riv_idx"].values[0] == 2
+    np.allclose(gdf_src.geometry[0].coords[:], [(322650.3, 5044385.7)])
     gdf_src = river_source_points(src_type="outflow", **kwargs)
+    np.allclose(gdf_src.geometry[0].coords[:], [(322554.0, 5044434.7)])
     assert gdf_src.index.size == 1  # this data only one river
-    assert gdf_src["riv_idx"].values[0] == 0
     gdf_src = river_source_points(src_type="headwater", **kwargs)
     assert gdf_src.index.size == 2
-    assert np.isin(2, gdf_src["riv_idx"].values)
 
     # test errors
     with pytest.raises(ValueError, match="src_type must be either"):

--- a/tests/test_flwdir.py
+++ b/tests/test_flwdir.py
@@ -46,13 +46,13 @@ def test_river_source_points(hydrography, data_catalog):
     kwargs = dict(gdf_riv=gdf_riv, gdf_mask=gdf_mask, reverse_river_geom=True)
     gdf_src = river_source_points(src_type="inflow", **kwargs)
     assert gdf_src.index.size == 1  # this data only one river
-    assert gdf_src["riv_idx"].values[0] == 38
+    assert gdf_src["riv_idx"].values[0] == 2
     gdf_src = river_source_points(src_type="outflow", **kwargs)
     assert gdf_src.index.size == 1  # this data only one river
-    assert gdf_src["riv_idx"].values[0] == 34
+    assert gdf_src["riv_idx"].values[0] == 0
     gdf_src = river_source_points(src_type="headwater", **kwargs)
     assert gdf_src.index.size == 2
-    assert np.isin(38, gdf_src["riv_idx"].values)
+    assert np.isin(2, gdf_src["riv_idx"].values)
 
     # test errors
     with pytest.raises(ValueError, match="src_type must be either"):


### PR DESCRIPTION
## Issue addressed
Fixes issue with multiple inflow points near confluence. 
In case of a confluence near the model region I want to be able to select the confluence (see figure b) rather than both tributaries as inflow points (see figure a). This is achieved by removing small river segments that completely fall within a user-defined buffer from the model boundary. The most upstream point of the remaining river is than located at the confluence.

**figure a: inflow at to closeby tributaries before fix**
![image](https://github.com/Deltares/hydromt_sfincs/assets/15379728/5063ff31-ee9d-4d7a-a7c7-6c8c510510de)

**figure b: inflow at confluence after fix**
![image](https://github.com/Deltares/hydromt_sfincs/assets/15379728/e3256726-47ac-45de-8442-aafb632770e8)


## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
