### PR TITLE
Update pyproject.toml to remove `geopandas v1.0.0` reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 dependencies = [
     "affine",
-    "geopandas>=1.0",
+    "geopandas>1.0",
     "hydromt>=0.10, <0.11",
     "numba",
     "numpy<2.0", # temp pin until bottleneck release v1.4


### PR DESCRIPTION
## Issue addressed
Fixes #217 
## Explanation
When users are building geopandas, there should be a better enforcement to ensure the buggy geopandas v1.0.0 is not used. this simple change will do just that.

## Checklist
- [ ] Updated tests or added new tests
- [X] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
