### PR TITLE
clean grid variables when recreating a grid

### DIFF
--- a/envs/hydromt-sfincs-dev.yml
+++ b/envs/hydromt-sfincs-dev.yml
@@ -8,7 +8,7 @@ dependencies:
 - cartopy
 - descartes
 - ffmpeg
-- geopandas>=1.0
+- geopandas>1.0
 - hydromt>=0.10, <0.11
 - jupyterlab
 - matplotlib

--- a/envs/hydromt-sfincs-min.yml
+++ b/envs/hydromt-sfincs-min.yml
@@ -5,8 +5,8 @@ channels:
 
 dependencies:
 - affine
-- geopandas>=0.8
-- hydromt>=0.9.1
+- geopandas>1.0
+- hydromt>=0.10, <0.11
 - numba
 - numpy
 - pandas

--- a/examples/build_from_script.ipynb
+++ b/examples/build_from_script.ipynb
@@ -357,9 +357,9 @@
     "# gdf_riv_buf = gdf_riv.assign(geometry=gdf_riv.buffer(gdf_riv['rivwth']/2))\n",
     "# da_manning = sf.grid.raster.rasterize(gdf_riv_buf, \"manning\", nodata=np.nan)\n",
     "\n",
-    "# use the river manning raster in combination with vito land to derive the manning roughness file\n",
+    "# use the river manning raster in combination with vito_2015 land to derive the manning roughness file\n",
     "# NOTE that we can combine in-memory data with data from the data catalog\n",
-    "# datasets_rgh = [{\"manning\": da_manning}, {\"lulc\": \"vito\"}]\n",
+    "# datasets_rgh = [{\"manning\": da_manning}, {\"lulc\": \"vito_2015\", \"reclass_table\": \"..\\\\hydromt_sfincs\\\\data\\\\lulc\\\\vito_mapping.csv\"}]\n",
     "\n",
     "# uncomment to plot either the raster or the vector data:\n",
     "# da_manning.plot(vmin=0, x='xc', y='yc', cmap='viridis')\n",
@@ -375,7 +375,12 @@
     "# 2. provide the manning value to the datasets_riv and burn in the river with a lower manning value\n",
     "# a global manning value can be provided to the datasets_riv, or a manning value per river segment can be provided\n",
     "# NOTE when using this method, we don't need to provide the river manning values to the datasets_rgh\n",
-    "datasets_rgh = [{\"lulc\": \"vito\"}]"
+    "datasets_rgh = [\n",
+    "    {\n",
+    "        \"lulc\": \"vito_2015\",\n",
+    "        \"reclass_table\": \"..\\\\hydromt_sfincs\\\\data\\\\lulc\\\\vito_mapping.csv\",\n",
+    "    }\n",
+    "]"
    ]
   },
   {
@@ -816,7 +821,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hydromt-sfincs",
+   "display_name": "hydromt-sfincs-dev",
    "language": "python",
    "name": "python3"
   },
@@ -830,12 +835,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "9ec3d1fca30a97858614ef59a1f03e9bb27fcbb0a81645b22c597c198da89e77"
-   }
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -206,6 +206,10 @@ class SfincsModel(GridModel):
         """
         # TODO gdf_refinement for quadtree
 
+        # clean old grid
+        self._grid = None
+
+        # setup regular grid
         self.config.update(
             x0=x0,
             y0=y0,

--- a/tests/data/local_data.yml
+++ b/tests/data/local_data.yml
@@ -26,3 +26,10 @@ observation_lines:
   data_type: GeoDataFrame
   driver: vector
   path: local_data/observation_lines.geojson
+
+vito_mapping:
+  data_type: DataFrame
+  driver: csv
+  driver_kwargs:
+    index_col: 0
+  path: local_data/vito_mapping.csv

--- a/tests/data/local_data/vito_mapping.csv
+++ b/tests/data/local_data/vito_mapping.csv
@@ -1,0 +1,24 @@
+vito,description,landuse,N
+20,Shrubs,20,0.05
+30,Herbaceous vegetation,30,0.034
+40,Cultivated and managed vegetation/agriculture (cropland),40,0.037
+50,Urban / built up,50,0.1
+60,Bare / sparse vegetation,60,0.023
+70,Snow and Ice,70,0.01
+80,Permanent water bodies,80,0.02
+90,Herbaceous wetland,90,0.035
+100,Moss and lichen,100,0.025
+111,Closed forest evergreen needle leaf,111,0.11
+112,Closed forest evergreen broad leaf,112,0.11
+113,Closed forest deciduous needle leaf,113,0.1
+114,Closed forest deciduous broad leaf,114,0.1
+115,Closed forest mixed,115,0.1
+116,Closed forest unknown,116,0.1
+121,Open forest evergreen needle leaf,121,0.11
+122,Open forest evergreen broad leaf,122,0.11
+123,Open forest deciduous needle leaf,123,0.1
+124,Open forest deciduous broad leaf,124,0.1
+125,Open forest mixed,125,0.1
+126,Open forest unknown,126,0.1
+200,Open sea,200,0.02
+0,No data,0,-999

--- a/tests/data/sfincs_test.yml
+++ b/tests/data/sfincs_test.yml
@@ -36,7 +36,8 @@ setup_subgrid:
       zmin: 0.001
     - elevtn: gebco
   datasets_rgh:
-    - lulc: vito
+    - lulc: vito_2015
+      reclass_table: vito_mapping
   write_dep_tif: True
   nr_subgrid_pixels: 5
   nbins: 8

--- a/tests/test_1model_class.py
+++ b/tests/test_1model_class.py
@@ -176,7 +176,7 @@ def test_subgrid_rivers(mod):
         datasets_rgh=[
             {
                 "lulc": "vito_2015",
-                "reclass_table": join(TESTDATADIR, "local_data\\vito_mapping.csv"),
+                "reclass_table": join(TESTDATADIR, "local_data, vito_mapping.csv"),
             }
         ],
         datasets_riv=[

--- a/tests/test_1model_class.py
+++ b/tests/test_1model_class.py
@@ -156,7 +156,7 @@ def test_subgrid_io(tmpdir):
 
 def test_subgrid_rivers(mod):
     gdf_riv = mod.data_catalog.get_geodataframe(
-        "rivers_lin2019_v1", geom=mod.region, buffer=1e3
+        "hydro_rivers_lin", geom=mod.region, buffer=1e3
     )
 
     # create dummy depths for the river based on the width
@@ -173,7 +173,12 @@ def test_subgrid_rivers(mod):
             {"elevtn": "merit_hydro", "zmin": 0.001},
             {"elevtn": "gebco"},
         ],
-        datasets_rgh=[{"lulc": "vito"}],
+        datasets_rgh=[
+            {
+                "lulc": "vito_2015",
+                "reclass_table": join(TESTDATADIR, "local_data\\vito_mapping.csv"),
+            }
+        ],
         datasets_riv=[
             {
                 "centerlines": gdf_riv,

--- a/tests/test_1model_class.py
+++ b/tests/test_1model_class.py
@@ -176,7 +176,7 @@ def test_subgrid_rivers(mod):
         datasets_rgh=[
             {
                 "lulc": "vito_2015",
-                "reclass_table": join(TESTDATADIR, "local_data, vito_mapping.csv"),
+                "reclass_table": join(TESTDATADIR, "local_data", "vito_mapping.csv"),
             }
         ],
         datasets_riv=[

--- a/tests/test_bathymetry.py
+++ b/tests/test_bathymetry.py
@@ -13,7 +13,7 @@ def test_bathymetry():
     da_man0 = xr.zeros_like(da_elv0)
     da_elv = da_elv0.raster.reproject(dst_crs="utm", dst_res=30).load()
     da_man = xr.zeros_like(da_elv)
-    gdf_riv = data_cat.get_geodataframe("rivers_lin2019_v1", bbox=bbox)
+    gdf_riv = data_cat.get_geodataframe("hydro_rivers_lin", bbox=bbox)
     da_mask = (data_cat.get_rasterdataset("grwl_mask", bbox=bbox) > 0).astype(np.uint8)
     da_mask.raster.set_nodata(0)
     gdf_mask = da_mask.raster.vectorize()

--- a/tests/test_flwdir.py
+++ b/tests/test_flwdir.py
@@ -43,7 +43,7 @@ def test_river_source_points(hydrography, data_catalog):
     np.allclose(gdf_src.geometry[0].coords[:], [(322650.3, 5044385.7)])
 
     # test reverse oriented line
-    gdf_riv = data_catalog.get_geodataframe("rivers_lin2019_v1")
+    gdf_riv = data_catalog.get_geodataframe("hydro_rivers_lin")
     kwargs = dict(gdf_riv=gdf_riv, gdf_mask=gdf_mask, reverse_river_geom=True)
     gdf_src = river_source_points(src_type="inflow", **kwargs)
     assert gdf_src.index.size == 1  # this data only one river


### PR DESCRIPTION
## Issue addressed
When re-running the setup_grid (or setup_grid_from_region) functions after you added a gridded varaible, dep or msk for example, the RegularGrid class was updated correctly, but the SfincsModel.grid seemed to stick on the first grid and therefore the model didn't update correctly.

Not sure when this was introduced, but espeically in a GUI, refining the grid after adding variables happens often, so this is a serious bug ...

## Explanation
setup_grid is always called when creating a new grid, so forcing the SfincsModel.grid to start blanco should solve the problem

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
