### PR TITLE
add nodata value to "empty array"

### DIFF
--- a/hydromt_sfincs/workflows/merge.py
+++ b/hydromt_sfincs/workflows/merge.py
@@ -99,6 +99,7 @@ def merge_multi_dataarrays(
             # no data in da1 so use an empty array like da_like
             logger.debug("No data da1, start with empty array")
             da1 = xr.full_like(da_like, np.nan)
+            da1.raster.set_nodata(np.nan)
         else:
             # TODO: this applies to the whole dataset, not only the clipped part
             da1 = da1.load().raster.reproject_like(da_like)


### PR DESCRIPTION
## Issue addressed
Fixes #<issue number>

## Explanation
When starting with a very small dataset, it is quite likely that da1 is an xarray full with nan values. Without a proper nodata value, we run into trouble in the merge function, hence added explicitly now.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
