### PR TITLE
fix overwrite lazy loaded files

### DIFF
--- a/tests/test_quadtree.py
+++ b/tests/test_quadtree.py
@@ -109,14 +109,13 @@ def test_overwrite_quadtree_nc_with_open_dataset_contextmanager(tmpdir):
         # Convert to dataset
         ds = uds.ugrid.to_dataset()
 
-        # Try to overwrite the file
         with pytest.raises(PermissionError):
+            # This fails because the file is open
             ds.to_netcdf(nc_copy)
+
+    # File is now closed
+    os.remove(nc_copy)
 
     with pytest.raises(KeyError):
         # This fails because not all data was read in!
         ds.to_netcdf(nc_copy)
-
-    with pytest.raises(PermissionError):
-        # This fails because the file is still open
-        os.remove(nc_copy)


### PR DESCRIPTION
## Issue addressed
Fixes #<issue number>

## Explanation
Ik zit een beetje te kijken naar die xu_open_dataset PR en ben steeds meer overtuigd dat jullie gewoon load dataset moeten gebruiken. 

Is hetzelfde principe als normaal files openen in python:
```python
fd = open(...)
......
fd.close()
```

of met context managers:
```python
with open(...) as fd:
   ....
```

Dit is precies wat load_dataset() doet, alleen dan leest die de hele ds uit. 
Als je maar een deel wil uitlezen, kan dat nog steeds met:
```python
ds = xr.open_dataset(...)
uds = UGridDataset(ds)
....
ds.close()
```

of met context manager:
```python
with xr.open_dataset(...) as ds:
  uds = UGridDataset(ds)
  ....
```

De schuld ligt bij xugrid, want die openen de file en doen er daarna niks meer mee, waardoor het anders is dan wat xarray doet.
Ik heb een testje erbij geschreven in je branch met wat extra uitleg.

Belangrijk te weten dat lazy loading dus eigenlijk alleen mogelijk is in dezelfde scope als waar je de file opent.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
