### PR TITLE
Set up structures

### DIFF
--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -1274,7 +1274,7 @@ class SfincsModel(GridModel):
 
     # Function to create curve number for SFINCS including recovery via saturated hydraulic conductivity [mm/hr]
     def setup_cn_infiltration_with_ks(
-        self, lulc, hsg, ksat, reclass_table, effective, factor_ksat=1, block_size=2000
+        self, lulc, hsg, ksat, reclass_table, effective, factor_ksat=1, smax_file = None, block_size=2000
     ):
         """Setup model the Soil Conservation Service (SCS) Curve Number (CN) files for SFINCS
         including recovery term based on the soil saturation
@@ -1382,6 +1382,12 @@ class SfincsModel(GridModel):
 
         # Convert ks - (e.g. from micrometer per second to mm/hr which is required in SFINCS)
         da_ks = da_ks * factor_ksat
+
+        if smax_file is not None:
+            da_smax = self.data_catalog.get_rasterdataset(
+                smax_file, bbox=self.bbox, buffer=10
+            )
+            self.logger.info("Smax provided will be used instead of calculated values")
 
         # Specify the effective soil retention (seff)
         da_seff = da_smax


### PR DESCRIPTION
**Explanation**
This PR improves how structure elevations (zb) are sampled by adding spatial buffering around each structure point to avoid large raster reads and ensure smoother sampling. Previously, the elevation was sampled directly from the point, which could be sensitive to pixel resolution or lead to inefficient raster access for high-resolution datasets.

**Key Changes:**

- Structure points are now buffered based on a configurable window_size (defaulting to res * 2 if not provided).
- Elevation raster is clipped to the buffered geometry using the data catalog method get_rasterdataset(...) with geom=buffer_geom.
- The sampling now uses the buffered clip, which improves stability and performance when sampling elevation data around structures.
- Code ensures crs is consistently applied when generating the points with gpd.points_from_xy(...).
- This change enhances robustness in elevation extraction and ensures the model setup better reflects localized terrain variability.

**Checklist**

- [ ] Updated tests or added new tests
- [ x] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed
-
Additional Notes (optional)
Consider reviewing performance for large numbers of structures. Buffering and raster clipping may benefit from parallelization or batching in future updates.




