### PR TITLE
add optional deps for xugrid so that burning in works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "scipy",
     "shapely",
     "xarray",
-    "xugrid>=0.14, <1.0",
+    "xugrid[all]>=0.14, <1.0",
 ]
 requires-python = ">=3.9" # fix tests to support older versions
 readme = "README.rst"


### PR DESCRIPTION
## Issue addressed
in Floodadapt we are running into errors that mapbox_earcut is not installed when we are using hydromt-sfincsv1.2.1. 
(from storage_volume.py -> add_storage_volume_qt -> xu.burn_vector_geometry ->  xugrid.ugrid.burn::_locate_polygon

This is in the xugrid optional deps, which is not a direct dependency for FA, so I added it here

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
