### PR TITLE
Ensure vmax is at least 1 for depth variable plots

### DIFF
--- a/hydromt_sfincs/plots.py
+++ b/hydromt_sfincs/plots.py
@@ -278,13 +278,13 @@ def plot_basemap(
     if "cmap" not in kwargs or "norm" not in kwargs:
         depth_vars = ["dep", "z"]
         if variable in depth_vars and variable in ds:
-# auto-determine vmin and vmax
-vmin, vmax = ds[variable].raster.mask_nodata().quantile([0.0, 0.98]).values
-# make sure vmin and vmax are different
-if vmin == vmax:
-   vmax = vmin + 1
-# overrule auto vmin and vmax with user input
-vmin, vmax = int(kwargs.pop("vmin", vmin)), int(kwargs.pop("vmax", vmax))
+            # auto-determine vmin and vmax
+            vmin, vmax = ds[variable].raster.mask_nodata().quantile([0.0, 0.98]).values
+            # make sure vmin and vmax are different
+            if vmin == vmax:
+                vmax = vmin + 1
+            # overrule auto vmin and vmax with user input
+            vmin, vmax = int(kwargs.pop("vmin", vmin)), int(kwargs.pop("vmax", vmax))
             c_dem = plt.cm.terrain(np.linspace(0.25, 1, vmax))
             if vmin < 0:
                 c_bat = plt.cm.terrain(np.linspace(0, 0.17, max(1, abs(vmin))))


### PR DESCRIPTION
## Issue addressed
Fixes #324 

## Explanation
When vmax is 0, c_dem becomes of size 0 and the colormap cannot be created

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
