### PR TITLE
limit sphinx and pandas version

### DIFF
--- a/hydromt_sfincs/__init__.py
+++ b/hydromt_sfincs/__init__.py
@@ -2,7 +2,7 @@
 
 from os.path import abspath, dirname, join
 
-__version__ = "2.0.0-rc1"
+__version__ = "2.0.0-dev"
 
 DATADIR = join(dirname(abspath(__file__)), "data")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "mapbox_earcut",
     "numba",
     "numpy",
-    "pandas",
+    "pandas<3.0.0",
     "pillow",
     "pyflwdir>=0.5.10",
     "pyproj",
@@ -53,7 +53,7 @@ doc = [
 	"nbsphinx",                     # build notebooks in docs
 	"pydata-sphinx-theme>=0.15.2",  # theme
 	"sphinx_autosummary_accessors", # doc layout
-	"sphinx",                       # build docks
+	"sphinx>=8.0.0,<9.0.0",         # build docs
 	"sphinx_design",                # doc layout
 	"autodoc_pydantic",             # pydantic autodoc
 ]


### PR DESCRIPTION
New pandas version introduced errors with the pandas timerange (it does not recognize the fequency 10T anymore), and also sphinx versions > 9.0 cause errors while building the documentation.

For now, we limit the versions, but later on, we should properly fix these.