### PR TITLE
Platform-aware launcher script (exe_path + write_batch_file)

### DIFF
--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -323,11 +323,19 @@ class SfincsModel(Model):
                 logger.warning(f"Could not read component {name}: {e}")
                 continue
 
-    def write(self):
+    def write(self, write_batch_file: bool = False):
         """Write SfincsModel to disk.
 
         This methods writes all components that actually contain data to the specified
         model root folder. Finally, the configuration file (sfincs.inp) is written.
+
+        Parameters
+        ----------
+        write_batch_file : bool, optional
+            If True, also write a platform-appropriate launcher script
+            (``run.bat`` on Windows, ``run.sh`` elsewhere) via
+            :meth:`write_batch_file`. Requires ``self.exe_path`` to be
+            set. Default ``False``.
 
         For more information, see specific component write methods.
         """
@@ -353,6 +361,10 @@ class SfincsModel(Model):
                 root=join(self.root.path, "gis"),
                 logger=logger,
             )
+
+        # Optional launcher script (opt-in; DDB passes True explicitly).
+        if write_batch_file:
+            self.write_batch_file()
 
     def clear_spatial_components(self):
         """Clear all spatial components."""

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -9,7 +9,7 @@ import logging
 import os
 from os.path import dirname, join
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import geopandas as gpd
 import numpy as np
@@ -147,7 +147,7 @@ class SfincsModel(Model):
         mode: str = "w",
         write_gis: bool = True,
         data_libs: Union[List[str], str] = None,
-        exe_path: Optional[str] = None,
+        exe_path: str = None,
         **catalog_keys,
     ):
         """
@@ -188,7 +188,7 @@ class SfincsModel(Model):
             instance = cls(self)
             self.add_component(name, instance)
 
-    def write_batch_file(self, filename: Optional[str] = None) -> Path:
+    def write_batch_file(self, filename: str = None) -> Path:
         """Write a platform-appropriate launcher script for SFINCS.
 
         On Windows this emits ``run.bat`` (``set HDF5_USE_FILE_LOCKING``);
@@ -218,16 +218,13 @@ class SfincsModel(Model):
         if is_windows:
             exe = Path(self.exe_path) / "sfincs.exe"
             script_path.write_text(
-                "set HDF5_USE_FILE_LOCKING=FALSE\n"
-                f"{exe}\n",
+                "set HDF5_USE_FILE_LOCKING=FALSE\n" f"{exe}\n",
                 encoding="ascii",
             )
         else:
             exe = Path(self.exe_path) / "sfincs"
             script_path.write_text(
-                "#!/bin/bash\n"
-                "export HDF5_USE_FILE_LOCKING=FALSE\n"
-                f'"{exe}"\n',
+                "#!/bin/bash\n" "export HDF5_USE_FILE_LOCKING=FALSE\n" f'"{exe}"\n',
                 encoding="ascii",
             )
             # Mark executable (ignore on systems that don't support it).

--- a/hydromt_sfincs/sfincs.py
+++ b/hydromt_sfincs/sfincs.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import logging
 import os
 from os.path import dirname, join
-from typing import Dict, List, Tuple, Union
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
 import geopandas as gpd
 import numpy as np
@@ -146,6 +147,7 @@ class SfincsModel(Model):
         mode: str = "w",
         write_gis: bool = True,
         data_libs: Union[List[str], str] = None,
+        exe_path: Optional[str] = None,
         **catalog_keys,
     ):
         """
@@ -162,6 +164,9 @@ class SfincsModel(Model):
             Write model files additionally to geotiff and geojson, by default True
         data_libs: List, str
             List of data catalog yaml files, by default None
+        exe_path: str, optional
+            Folder containing the ``sfincs.exe`` binary; used by
+            :meth:`write_batch_file`. Defaults to ``None``.
         **catalog_keys:
             Additional keyword arguments to be passed down to the DataCatalog.
         """
@@ -169,6 +174,7 @@ class SfincsModel(Model):
         # define some default model properties
         self._grid_type = None
         self.write_gis = write_gis
+        self.exe_path = exe_path
 
         super().__init__(
             root=root,
@@ -181,6 +187,56 @@ class SfincsModel(Model):
         for name, cls in self._ALL_COMPONENTS.items():
             instance = cls(self)
             self.add_component(name, instance)
+
+    def write_batch_file(self, filename: Optional[str] = None) -> Path:
+        """Write a platform-appropriate launcher script for SFINCS.
+
+        On Windows this emits ``run.bat`` (``set HDF5_USE_FILE_LOCKING``);
+        on Linux / macOS it emits ``run.sh`` (``#!/bin/bash`` + ``export``
+        + executable bit). The SFINCS binary itself is expected to be
+        ``sfincs.exe`` on Windows and ``sfincs`` elsewhere.
+
+        Parameters
+        ----------
+        filename : str, optional
+            Override the output file name. Defaults to ``run.bat`` on
+            Windows and ``run.sh`` on other platforms.
+
+        Returns
+        -------
+        Path
+            The path of the written launcher script.
+        """
+        if not self.exe_path:
+            raise ValueError(
+                "exe_path not set on SfincsModel; cannot write launcher script."
+            )
+        is_windows = os.name == "nt"
+        if filename is None:
+            filename = "run.bat" if is_windows else "run.sh"
+        script_path = Path(self.root.path) / filename
+        if is_windows:
+            exe = Path(self.exe_path) / "sfincs.exe"
+            script_path.write_text(
+                "set HDF5_USE_FILE_LOCKING=FALSE\n"
+                f"{exe}\n",
+                encoding="ascii",
+            )
+        else:
+            exe = Path(self.exe_path) / "sfincs"
+            script_path.write_text(
+                "#!/bin/bash\n"
+                "export HDF5_USE_FILE_LOCKING=FALSE\n"
+                f'"{exe}"\n',
+                encoding="ascii",
+            )
+            # Mark executable (ignore on systems that don't support it).
+            try:
+                st = script_path.stat().st_mode
+                script_path.chmod(st | 0o111)
+            except OSError:
+                pass
+        return script_path
 
     def __del__(self):
         """Close the model and remove the logger file handler."""


### PR DESCRIPTION
## Summary
- New `exe_path` kwarg / attribute on `SfincsModel`.
- New `write_batch_file(filename=None)` method: `run.bat` on Windows (`set HDF5_USE_FILE_LOCKING=FALSE` + `<exe_path>\sfincs.exe`) and `run.sh` on Linux/macOS (`#!/bin/bash` + `export ...` + executable bit). Raises when `exe_path` is unset.
- `SfincsModel.write(write_batch_file=False)` gains an opt-in kwarg that calls `self.write_batch_file()` after the main write. Default `False` so script users don't get a surprise file.

## Test plan
- [ ] Instantiate `SfincsModel(exe_path=...)` on each OS; confirm the right script type is emitted
- [ ] `write_batch_file()` raises cleanly when `exe_path` is `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)