### PR TITLE
Refactor map overlay + tiling/COG into workflow modules

### DIFF
--- a/hydromt_sfincs/components/forcing/water_level.py
+++ b/hydromt_sfincs/components/forcing/water_level.py
@@ -123,6 +123,29 @@ class SfincsWaterLevel(SfincsBoundaryBase):
         df.columns.name = "index"
         return df
 
+    def set_boundary_conditions_astro(self, gdf: gpd.GeoDataFrame) -> None:
+        """Populate boundary points and astronomical constituents from a gdf.
+
+        The gdf is expected to have an ``"astro"`` column in which each
+        entry is a pandas DataFrame indexed by constituent name with
+        ``amplitude`` and ``phase`` columns (i.e. the format returned by
+        :py:meth:`cht_tide.model.TideModel.get_data_on_points` with
+        ``format="gdf"``).
+
+        Parameters
+        ----------
+        gdf : gpd.GeoDataFrame
+            Boundary points with per-station constituent data.
+        """
+        if "astro" not in gdf.columns:
+            raise ValueError(
+                "gdf must have an 'astro' column with per-point constituent data."
+            )
+        section_data = list(gdf["astro"])
+        gdf_points = gdf.drop(columns=["astro"])
+        self.set(gdf=gdf_points, merge=False, drop_duplicates=False)
+        self._data = add_constituents(self.data, section_data)
+
     def read_boundary_conditions_astro(self, filename: str | Path = None):
         """Read SFINCS boundary condition astro (.bca) file"""
 
@@ -292,11 +315,8 @@ class SfincsWaterLevel(SfincsBoundaryBase):
 
         with open(abs_file_path, "w") as fid:
             for ip in self.data.index.values:
-                # Optional: if you have names from your dataset
-                if "name" in self.data.coords:
-                    name = f"sfincs_{int(self.data.name.sel(index=ip).item()):04d}"
-                else:
-                    name = f"sfincs_{ip+1:04d}"
+
+                name = f"sfincs_{ip+1:04d}"
 
                 fid.write(f"[forcing]\n")
                 fid.write(f"Name                            = {name}\n")

--- a/hydromt_sfincs/components/grid/mask.py
+++ b/hydromt_sfincs/components/grid/mask.py
@@ -13,17 +13,6 @@ from hydromt.model.components import ModelComponent
 
 from hydromt_sfincs import utils
 
-# optional dependency
-try:
-    import datashader as ds
-    import datashader.transfer_functions as tf
-    from datashader.utils import export_image
-
-    HAS_DATASHADER = True
-
-except ImportError:
-    HAS_DATASHADER = False
-
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
 
@@ -58,7 +47,6 @@ class SfincsMask(ModelComponent):
             model=model,
         )
         # For plotting map overlay (This is the only data that is stored in the object! All other data is stored in the model.grid.data["mask"])
-        # self.datashader_dataframe = pd.DataFrame()
 
     @property
     def data(self):
@@ -608,15 +596,3 @@ class SfincsMask(ModelComponent):
         else:
             return False
 
-    def get_datashader_dataframe(self):
-        raise NotImplementedError(
-            "Datashader dataframe not yet implemented for regular models"
-        )
-
-    def clear_datashader_dataframe(self):
-        """Clear the datashader dataframe."""
-        if hasattr(self, "datashader_dataframe"):
-            self.datashader_dataframe = pd.DataFrame()
-
-    def map_overlay(self):
-        raise NotImplementedError("Map overlay not yet implemented for regular models")

--- a/hydromt_sfincs/components/grid/regulargrid.py
+++ b/hydromt_sfincs/components/grid/regulargrid.py
@@ -61,7 +61,6 @@ class SfincsGrid(GridComponent):
         )
         # initialize data attribute
         self._data = None
-        self.datashader_dataframe = pd.DataFrame()
 
     @property
     def transform(self):
@@ -619,37 +618,10 @@ class SfincsGrid(GridComponent):
         lines = [LineString([(x1[i], y1[i]), (x2[i], y2[i])]) for i in range(len(x1))]
         return gpd.GeoDataFrame(geometry=lines, crs=self.model.crs)
 
-    def get_datashader_dataframe(self):
-        """Create a datashader-friendly DataFrame for the regular grid."""
-        x1, y1, x2, y2 = self._get_grid_lines()
-
-        # Check if the grid crosses the dateline
-        cross_dateline = False
-        if self.model.crs.is_geographic:
-            if np.max(x1) > 180.0 or np.max(x2) > 180.0:
-                cross_dateline = True
-
-        # Transform to Web Mercator for Datashader
-        transformer = Transformer.from_crs(self.model.crs, 3857, always_xy=True)
-        x1, y1 = transformer.transform(x1, y1)
-        x2, y2 = transformer.transform(x2, y2)
-
-        # Handle dateline wrapping
-        if cross_dateline:
-            x1[x1 < 0] += 40075016.68557849
-            x2[x2 < 0] += 40075016.68557849
-
-        self.datashader_dataframe = pd.DataFrame(dict(x1=x1, y1=y1, x2=x2, y2=y2))
-
-    def clear_datashader_dataframe(self):
-        """Clears the datashader dataframe"""
-        self.datashader_dataframe = pd.DataFrame()
-
     # %% DDB GUI focused additional functions:
     # create_index_tiles > FIXME - TL: still needed?
     # map_overlay
     # snap_to_grid
-    # _get_datashader_dataframe
 
     # TODO - missing as in cht_sfincs:
     # Many...

--- a/hydromt_sfincs/components/grid/regulargrid.py
+++ b/hydromt_sfincs/components/grid/regulargrid.py
@@ -20,7 +20,7 @@ from hydromt.model.components import GridComponent
 from hydromt.model.processes.grid import create_grid_from_region
 
 from hydromt_sfincs import utils
-from hydromt_sfincs.workflows.tiling import int2png, tile_window
+from hydromt_sfincs.workflows.tiling import int2png, tile_window, write_html
 
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
@@ -660,6 +660,7 @@ class SfincsGrid(GridComponent):
         region: gpd.GeoDataFrame,
         zoom_range: Union[int, List[int]] = [0, 13],
         fmt: str = "bin",
+        write_html_viewer: bool = True,
         logger: logging.Logger = logger,
     ):
         """Create index tiles for a region. Index tiles are used to quickly map webmercator tiles to the corresponding SFINCS cell.
@@ -674,6 +675,9 @@ class SfincsGrid(GridComponent):
             Range of zoom levels for which tiles are created, by default [0,13]
         fmt : str, optional
             Format of index tiles, either "bin" (binary, default) or "png"
+        write_html_viewer : bool, optional
+            If True (default), also write an ``index.html`` Leaflet viewer
+            alongside the tiles so they can be previewed in a browser.
         """
 
         index_path = os.path.join(root, "indices")
@@ -763,6 +767,15 @@ class SfincsGrid(GridComponent):
                         # for png, change nodata -999 nodata into 0
                         ind[ind == -999] = 0
                         int2png(ind, file_name)
+
+        if write_html_viewer and fmt == "png":
+            os.makedirs(index_path, exist_ok=True)
+            write_html(
+                os.path.join(index_path, "index.html"),
+                title="Index tiles",
+                legend_title="Cell indices",
+                max_native_zoom=zoom_range[1],
+            )
 
     def get_indices_at_points(self, x, y):
         # x and y are 2D arrays of coordinates (x, y) in the same projection as the model

--- a/hydromt_sfincs/components/quadtree/quadtree.py
+++ b/hydromt_sfincs/components/quadtree/quadtree.py
@@ -1,19 +1,21 @@
+"""Quadtree grid component for the SFINCS model.
+
+Defines :class:`SfincsQuadtreeGrid`, a mesh-backed grid that supports
+multi-level refinement. Provides I/O, grid construction, mask / bathymetry
+handling, point-to-cell lookup, tiled index output for web viewers, and
+utilities used by DelftDashboard such as map overlays and grid snapping.
+"""
+
 import logging
 import os
-import gc
 from os.path import isfile
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Union
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 from pyproj import CRS, Transformer
 import shapely
-import rasterio
-from rasterio.transform import from_origin
-from rasterio.enums import Resampling
 
 import xarray as xr
 import xugrid as xu
@@ -23,17 +25,16 @@ from hydromt.model.components import MeshComponent
 from hydromt.model.processes.grid import create_grid_from_region
 
 from hydromt_sfincs.utils import make_regular_grid
+from hydromt_sfincs.workflows.cog import make_index_cog, make_topobathy_cog
+from hydromt_sfincs.workflows.map_overlay import MeshOverlay
+from hydromt_sfincs.workflows.tiling import (
+    create_topobathy_tiles,
+    int2png,
+    make_index_tiles,
+    tile_window,
+    write_html,
+)
 from .quadtree_builder import build_quadtree_xugrid, cut_inactive_cells
-
-# optional dependency
-try:
-    import datashader.transfer_functions as tf
-    from datashader import Canvas
-    from datashader.utils import export_image
-
-    HAS_DATASHADER = True
-except ImportError:
-    HAS_DATASHADER = False
 
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
@@ -44,14 +45,17 @@ _QT_MAPS = ["manning", "vol", "ini"]
 
 
 class SfincsQuadtreeGrid(MeshComponent):
+    """Quadtree grid component attached to an :class:`SfincsModel`."""
+
     def __init__(
         self,
         model: "SfincsModel",
-    ):
+    ) -> None:
+        """Initialise the component with a back-reference to its parent model."""
         self._filename: str = "sfincs.nc"
         self._data: xu.UgridDataset = None
         self.version = 0
-        self.datashader_dataframe = pd.DataFrame()
+        self._overlay = MeshOverlay()
 
         super().__init__(
             model=model,
@@ -68,14 +72,30 @@ class SfincsQuadtreeGrid(MeshComponent):
             raise ValueError("No CRS defined for the quadtree grid.")
 
     @property
-    def face_coordinates(self):
+    def face_coordinates(self) -> Optional[tuple]:
+        """Return the (x, y) coordinates of the cell face centres.
+
+        Returns
+        -------
+        tuple of np.ndarray, or None
+            A pair ``(x, y)`` of 1-D arrays with cell centre coordinates in
+            the model CRS, or ``None`` if no grid has been loaded.
+        """
         if self.data is None:
             return None
         xy = self.data.grid.face_coordinates
         return xy[:, 0], xy[:, 1]
 
     @property
-    def exterior(self):
+    def exterior(self) -> gpd.GeoDataFrame:
+        """Return the outer boundary of the active grid as polygons.
+
+        Returns
+        -------
+        geopandas.GeoDataFrame
+            Polygon geometries in the model CRS, or an empty GeoDataFrame
+            if no grid has been loaded.
+        """
         if self.data is None:
             return gpd.GeoDataFrame()
         indx = self.data.grid.edge_node_connectivity[self.data.grid.exterior_edges, :]
@@ -94,7 +114,8 @@ class SfincsQuadtreeGrid(MeshComponent):
         return gpd.GeoDataFrame(geometry=list(polygons), crs=self.crs)
 
     @property
-    def empty_mask(self):
+    def empty_mask(self) -> Optional[xu.UgridDataArray]:
+        """Return an all-zero mask with the shape of the current grid."""
         if self.data is None:
             return None
         # create empty mask
@@ -113,7 +134,9 @@ class SfincsQuadtreeGrid(MeshComponent):
             da_mask = self.empty_mask
         return da_mask
 
-    def read(self, filename: Union[str, Path] = None, data_vars: List[dict] = None):
+    def read(
+        self, filename: Union[str, Path] = "sfincs.nc", data_vars: List[dict] = None
+    ):
         """Reads a quadtree netcdf file and stores it in the QuadtreeGrid object.
 
         Parameters
@@ -183,8 +206,7 @@ class SfincsQuadtreeGrid(MeshComponent):
             for var in variables:
                 try:
                     with xu.load_dataset(var["file_name"]) as ds:
-                        ds.grid.set_crs(self.model.crs)
-                        self.set(ds)
+                        self._data[var["variable"]] = ds[var["variable"]]
                 except Exception as e:
                     logger.error(f"Error reading variable {var['variable']}: {e}")
                     continue
@@ -232,7 +254,7 @@ class SfincsQuadtreeGrid(MeshComponent):
                     # get the single variable and convert to dataset
                     # NOTE this allows to read as a standalone file with spatial metadata
                     ds_var = self.data[
-                        var["variable"] + ["mesh2d_node_x", "mesh2d_node_y"]
+                        [var["variable"], "mesh2d_node_x", "mesh2d_node_y"]
                     ].ugrid.to_dataset()
                     ds_var.to_netcdf(var["file_name"])
                     # drop the variable from ds
@@ -301,12 +323,12 @@ class SfincsQuadtreeGrid(MeshComponent):
             Bathymetry database object.
         """
 
-        # Clear datashader dataframes
-        self.clear_datashader_dataframe()
-        self.model.quadtree_mask.clear_datashader_dataframe()
+        # Invalidate cached overlays (grid + mask)
+        self._overlay.invalidate()
+        self.model.quadtree_mask.clear_overlay()
 
         # Set grid type and crs in model
-        self.model._grid_type = "quadtree"
+        self.model.grid_type = "quadtree"
         crs = CRS.from_epsg(epsg)
 
         elevation_list_per_level = []
@@ -332,7 +354,7 @@ class SfincsQuadtreeGrid(MeshComponent):
             elevation_list = elevation_list_per_level
 
         # Build the quadtree grid
-        ds = build_quadtree_xugrid(
+        self._data = build_quadtree_xugrid(
             x0,
             y0,
             nmax,
@@ -345,10 +367,6 @@ class SfincsQuadtreeGrid(MeshComponent):
             elevation_list=elevation_list,
             bathymetry_database=bathymetry_database,
         )
-        # add nFaces coordinates to grid
-        ds = xu.UgridDataset(ds.ugrid.to_dataset())
-        ds.grid.set_crs(CRS.from_wkt(ds["crs"].crs_wkt))
-        self._data = ds
 
         # Make sure epsg is stored in the config as well
         self.model.config.set("epsg", self.model.crs.to_epsg())
@@ -456,15 +474,33 @@ class SfincsQuadtreeGrid(MeshComponent):
             elevation_list=elevation_list,
         )
 
-    def cut_inactive_cells(self):
-        # Clear datashader dataframes (new ones will be created when needed by map_overlay methods)
-        self.clear_datashader_dataframe()
-        self.model.quadtree_mask.clear_datashader_dataframe()
-        # Cut inactive cells
+    @hydromt_step
+    def cut_inactive_cells(self) -> None:
+        """Remove cells that are outside the active mask from the grid.
+
+        Also invalidates any cached overlays so rendering picks up the
+        new geometry on the next call.
+        """
+        self._overlay.invalidate()
+        self.model.quadtree_mask.clear_overlay()
         self._data = cut_inactive_cells(self.data)
         # self.get_exterior() # FIXME - TL: why is this needed in cht_sfincs? > also, is now a property
 
-    def snap_to_grid(self, polyline):
+    def snap_to_grid(self, polyline: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+        """Snap a set of lines to the edges of the quadtree grid.
+
+        Parameters
+        ----------
+        polyline : geopandas.GeoDataFrame
+            Input lines to snap. Only ``LineString`` geometries are used;
+            other geometry types are ignored.
+
+        Returns
+        -------
+        geopandas.GeoDataFrame
+            Snapped lines in the model CRS, or an empty GeoDataFrame if the
+            input is empty.
+        """
         if len(polyline) == 0:
             return gpd.GeoDataFrame()
         # If geographic coordinates, set max_snap_distance to 0.1 degrees
@@ -485,71 +521,53 @@ class SfincsQuadtreeGrid(MeshComponent):
         snapped_gdf = snapped_gdf.set_crs(self.crs)
         return snapped_gdf
 
-    def map_overlay(self, file_name, xlim=None, ylim=None, color="black", width=800):
-        """Create a map overlay of the grid
+    def map_overlay(
+        self,
+        file_name: Union[str, Path],
+        xlim: Optional[List[float]] = None,
+        ylim: Optional[List[float]] = None,
+        color: str = "black",
+        width: int = 800,
+    ) -> bool:
+        """Render a PNG map overlay of the grid edges.
+
+        One-line wrapper around
+        :py:class:`hydromt_sfincs.workflows.map_overlay.MeshOverlay`.
+        """
+        if self.data is None:
+            return False
+        return self._overlay.render(
+            ugrid=self.data.grid,
+            source_crs=self.model.crs,
+            file_name=file_name,
+            xlim=xlim,
+            ylim=ylim,
+            color=color,
+            width=width,
+        )
+
+    def get_indices_at_points(self, x: np.ndarray, y: np.ndarray) -> np.ndarray:
+        """Return the cell index at each (x, y) sample.
+
+        Resolves the quadtree by traversing refinement levels from coarse
+        to fine; points that do not fall inside any active cell at any
+        level are returned as ``-999``.
 
         Parameters
         ----------
-        file_name : str | Path
-            File name of the map overlay
-        xlim : list, optional
-            x-axis limits (longitude)
-        ylim : list, optional
-            y-axis limits (latitude)
-        color : str, optional
-            Color of the grid lines
-        width : int, optional
-            Width of the map overlay in pixels
+        x : np.ndarray
+            2-D array of x-coordinates in the model CRS (scalars are
+            promoted to shape ``(1, 1)``).
+        y : np.ndarray
+            2-D array of y-coordinates in the model CRS, same shape as
+            ``x``.
 
         Returns
         -------
-        bool
-            True if the map overlay was created successfully, False otherwise
+        np.ndarray
+            2-D ``int32`` array with the cell index for each sample, or
+            ``-999`` for samples outside the active grid.
         """
-        # TODO: xlim and ylim should not be optional and be called lonlim and latlim or just give bbox
-
-        # check if datashader is available
-        if not HAS_DATASHADER:
-            logger.warning("Datashader is not available. Please install datashader.")
-            return False
-
-        if self.data is None:
-            # No grid (yet)
-            return False
-
-        try:
-            # Check if datashader dataframe is empty (maybe it was not made yet, or it was cleared)
-            if self.datashader_dataframe.empty:
-                self.get_datashader_dataframe()
-
-            transformer = Transformer.from_crs(4326, 3857, always_xy=True)
-            xl0, yl0 = transformer.transform(xlim[0], ylim[0])
-            xl1, yl1 = transformer.transform(xlim[1], ylim[1])
-            if xl0 > xl1:
-                xl1 += 40075016.68557849
-            xlim = [xl0, xl1]
-            ylim = [yl0, yl1]
-            ratio = (ylim[1] - ylim[0]) / (xlim[1] - xlim[0])
-            height = int(width * ratio)
-            cvs = Canvas(
-                x_range=xlim, y_range=ylim, plot_height=height, plot_width=width
-            )
-            agg = cvs.line(
-                self.datashader_dataframe, x=["x1", "x2"], y=["y1", "y2"], axis=1
-            )
-            img = tf.shade(agg, cmap=color)
-            path = os.path.dirname(file_name)
-            if not path:
-                path = os.getcwd()
-            name = os.path.basename(file_name)
-            name = os.path.splitext(name)[0]
-            export_image(img, name, export_path=path)
-            return True
-        except Exception:
-            return False
-
-    def get_indices_at_points(self, x, y):
-        # x and y are 2D arrays of coordinates (x, y) in the same projection as the model
         # if x is a float, convert to 2D array
         if np.ndim(x) == 0:
             x = np.array([[x]])
@@ -581,9 +599,9 @@ class SfincsQuadtreeGrid(MeshComponent):
             ifirst = np.zeros(nr_refinement_levels, dtype=int)
             for ilev in range(0, nr_refinement_levels):
                 # Find index of first cell with this level
-                levels = self.data["level"].to_numpy()[:]
-                indices = np.where(levels == ilev + 1)[0]
-                ifirst[ilev] = indices[0]
+                ifirst[ilev] = np.where(self.data["level"].to_numpy()[:] == ilev + 1)[
+                    0
+                ][0]
             self.ifirst = ifirst
 
         ifirst = self.ifirst
@@ -626,10 +644,13 @@ class SfincsQuadtreeGrid(MeshComponent):
             ind[jind < 0] = -999
             ind[iind >= mmax] = -999
             ind[jind >= nmax] = -999
-            # return boolean for each pixel that falls inside a grid cell
-            ingrid = np.isin(ind, nm_lev[ilev], assume_unique=False)
-            # tuple of arrays of pixel indices that fall in a cell
-            incell = np.where(ingrid)
+
+            ingrid = np.isin(
+                ind, nm_lev[ilev], assume_unique=False
+            )  # return boolean for each pixel that falls inside a grid cell
+            incell = np.where(
+                ingrid
+            )  # tuple of arrays of pixel indices that fall in a cell
 
             if incell[0].size > 0:
                 # Now find the cell indices
@@ -645,189 +666,220 @@ class SfincsQuadtreeGrid(MeshComponent):
 
         return indx
 
-    # Internal functions
-    def get_datashader_dataframe(self):
-        """Creates a dataframe with line elements for datashader"""
-        x1 = self.data.grid.edge_node_coordinates[:, 0, 0]
-        x2 = self.data.grid.edge_node_coordinates[:, 1, 0]
-        y1 = self.data.grid.edge_node_coordinates[:, 0, 1]
-        y2 = self.data.grid.edge_node_coordinates[:, 1, 1]
-        # Check if grid crosses the dateline
-        cross_dateline = False
-        if self.model.crs.is_geographic:
-            if np.max(x1) > 180.0 or np.max(x2) > 180.0:
-                cross_dateline = True
-        transformer = Transformer.from_crs(self.model.crs, 3857, always_xy=True)
-        x1, y1 = transformer.transform(x1, y1)
-        x2, y2 = transformer.transform(x2, y2)
-        if cross_dateline:
-            x1[x1 < 0] += 40075016.68557849
-            x2[x2 < 0] += 40075016.68557849
-        self.datashader_dataframe = pd.DataFrame(dict(x1=x1, y1=y1, x2=x2, y2=y2))
+    def clear_overlay(self) -> None:
+        """Invalidate the cached edge-overlay dataframe."""
+        self._overlay.invalidate()
 
-    def clear_datashader_dataframe(self):
-        """Clears the datashader dataframe"""
-        self.datashader_dataframe = pd.DataFrame()
+    def create_topobathy_cog(
+        self,
+        filename: Union[str, Path],
+        bathymetry_sets: List[dict],
+        bathymetry_database: Optional[object] = None,
+        dx: float = 10.0,
+    ) -> None:
+        """Write a COG raster sampling the model topobathy.
 
-    def make_topobathy_cog(
-        self, filename, bathymetry_sets, bathymetry_database=None, dx=10.0
-    ):
-        """Make a COG file with topobathy. Now only works for projected coordinates. This always make the topobathy COG in the same projection as the model."""
+        Thin wrapper around
+        :py:func:`hydromt_sfincs.workflows.cog.make_topobathy_cog`.
 
-        # Get the bounds of the grid
-        bounds = self.bounds
-
-        x0 = bounds[0]
-        y0 = bounds[1]
-        x1 = bounds[2]
-        y1 = bounds[3]
-
-        # Round up and down to nearest dx
-        x0 = x0 - (x0 % dx)
-        x1 = x1 + (dx - x1 % dx)
-        y0 = y0 - (y0 % dx)
-        y1 = y1 + (dx - y1 % dx)
-
-        xx = np.arange(x0, x1, dx) + 0.5 * dx
-        yy = np.arange(y1, y0, -dx) - 0.5 * dx
-        zz = np.empty(
-            (
-                len(yy),
-                len(xx),
-            ),
-            dtype=np.float32,
+        Parameters
+        ----------
+        filename : str or Path
+            Output COG file path.
+        bathymetry_sets : list of dict
+            Dataset list passed through to
+            ``bathymetry_database.get_bathymetry_on_points``.
+        bathymetry_database : object, optional
+            Backing bathymetry database providing
+            ``get_bathymetry_on_points``. Required for this method to
+            produce data.
+        dx : float, optional
+            Raster resolution in model CRS units, by default ``10.0``.
+        """
+        make_topobathy_cog(
+            quadtree_grid=self,
+            filename=filename,
+            bathymetry_sets=bathymetry_sets,
+            bathymetry_database=bathymetry_database,
+            dx=dx,
         )
 
-        xx, yy = np.meshgrid(xx, yy)
-        zz = bathymetry_database.get_bathymetry_on_points(
-            xx, yy, dx, self.model.crs, bathymetry_sets
+    def create_index_tiles(
+        self,
+        root: Union[str, Path],
+        region: Optional[gpd.GeoDataFrame] = None,
+        zoom_range: Union[int, List[int]] = [0, 13],
+        fmt: str = "png",
+        write_html_viewer: bool = True,
+        max_workers: Optional[int] = None,
+        logger: logging.Logger = logger,
+    ) -> None:
+        """Create webmercator index tiles for this quadtree grid.
+
+        Thin wrapper around
+        :py:func:`hydromt_sfincs.workflows.tiling.make_index_tiles`.
+
+        Parameters
+        ----------
+        root : Union[str, Path]
+            Parent directory; tiles land in ``<root>/indices``.
+        region : gpd.GeoDataFrame, optional
+            Area for which tiles are generated. Defaults to the grid
+            exterior.
+        zoom_range : Union[int, List[int]], optional
+            Range of zoom levels, by default ``[0, 13]``.
+        fmt : str, optional
+            ``"png"`` (default) or ``"bin"`` (raw int32).
+        write_html_viewer : bool, optional
+            If True (default) and ``fmt == "png"``, also write an
+            ``index.html`` Leaflet viewer alongside the tiles.
+        max_workers : int, optional
+            Number of worker threads used to render tiles concurrently.
+            Defaults to ``os.cpu_count()``. Pass ``1`` to disable
+            parallelism.
+        """
+        make_index_tiles(
+            quadtree_grid=self,
+            root=root,
+            region=region,
+            zoom_range=zoom_range,
+            fmt=fmt,
+            write_html_viewer=write_html_viewer,
+            max_workers=max_workers,
+            logger=logger,
         )
 
-        # And now to cog (use -999 as the nodata value)
-        with rasterio.open(
-            filename,
-            "w",
-            driver="COG",
-            height=zz.shape[0],
-            width=zz.shape[1],
-            count=1,
-            dtype=zz.dtype,
-            crs=self.model.crs,
-            transform=from_origin(x0, y1, dx, dx),
-            nodata=-999.0,
-        ) as dst:
-            dst.write(zz, 1)
+    def create_topobathy_tiles(
+        self,
+        root: Union[str, Path],
+        elevation_list: Optional[List[dict]] = None,
+        region: Optional[gpd.GeoDataFrame] = None,
+        index_path: Optional[Union[str, Path]] = None,
+        zoom_range: Union[int, List[int]] = [0, 13],
+        z_range: List[float] = [-20000.0, 20000.0],
+        fmt: str = "bin",
+        write_html_viewer: bool = True,
+        max_workers: Optional[int] = None,
+        logger: logging.Logger = logger,
+    ) -> None:
+        """Create webmercator topobathy tiles for this quadtree grid.
 
-    def make_index_cog(self, filename, filename_topobathy):
-        # def make_index_cog(self, filename, dx=10.0):
-        """Make a COG file with indices of the quadtree grid cells."""
+        Thin wrapper around
+        :py:func:`hydromt_sfincs.workflows.tiling.create_topobathy_tiles`.
 
-        # Read coordinates from topobathy file
-        with rasterio.open(filename_topobathy) as src:
-            # Get the bounds of the grid
-            bounds = src.bounds
-            dx = src.res[0]
-            # Get the CRS of the grid
-            crs = src.crs
-            # Get the nodata value
-            nodata = src.nodata
-            # Get the transform of the grid
-            transform = src.transform
-            # Get the width and height of the grid
-            width = src.width
-            height = src.height
+        Parameters
+        ----------
+        root : Union[str, Path]
+            Parent directory; tiles land in ``<root>/topobathy``.
+        elevation_list : List[dict], optional
+            Topobathy datasets. Entries may be in DDB name-only format
+            (``{"name": ..., "zmin": ..., "zmax": ...}``) or hydromt format
+            (with a ``"da"`` DataArray). DDB entries are auto-resolved via
+            the model's data catalog. If ``None``, all sources in the
+            model's data catalog are used instead.
+        region : gpd.GeoDataFrame, optional
+            Area for which tiles are generated. Defaults to the grid
+            exterior.
+        index_path : Union[str, Path], optional
+            Directory containing index tiles; if given, topobathy tiles
+            are only written where index tiles exist.
+        zoom_range : Union[int, List[int]], optional
+            Range of zoom levels, by default ``[0, 13]``.
+        z_range : List[float], optional
+            Valid elevation range; tiles entirely outside are skipped.
+        fmt : str, optional
+            ``"bin"`` (default), ``"png"``, or ``"tif"``.
+        write_html_viewer : bool, optional
+            If True (default) and ``fmt == "png"``, also write an
+            ``index.html`` Leaflet viewer alongside the tiles.
+        max_workers : int, optional
+            Number of worker threads used to render tiles concurrently.
+            Defaults to ``os.cpu_count()``. Pass ``1`` to disable
+            parallelism.
+        """
+        if region is None:
+            region = self.exterior
 
-        # Now create numpy arrays with the coordinates of geotiff
-        # Get the coordinates of the grid
-        x0 = bounds.left
-        y0 = bounds.bottom
-        x1 = bounds.right
-        y1 = bounds.top
+        if isinstance(zoom_range, int):
+            zr = [0, zoom_range]
+        else:
+            zr = zoom_range
 
-        # # Round up and down to nearest dx
-        # x0 = x0 - (x0 % dx)
-        # x1 = x1 + (dx - x1 % dx)
-        # y0 = y0 - (y0 % dx)
-        # y1 = y1 + (dx - y1 % dx)
+        # Auto-convert DDB-format elevation_list (name-only) to hydromt format
+        if elevation_list and "da" not in elevation_list[0]:
+            res = 40075016.686 / 256 / 2 ** zr[1]
+            elevation_list = self.model._parse_datasets_elevation(
+                elevation_list, res=res
+            )
 
-        xx = np.arange(x0, x1, dx) + 0.5 * dx
-        yy = np.arange(y1, y0, -dx) - 0.5 * dx
+        # When no elevation_list is given, the workflow falls back to the
+        # model's data catalog (if populated).
+        data_catalog = self.model.data_catalog if elevation_list is None else None
 
-        nodata = 2147483647
-
-        # # # Get the bounds of the grid
-        # # bounds = self.bounds()
-
-        # x0 = bounds[0]
-        # y0 = bounds[1]
-        # x1 = bounds[2]
-        # y1 = bounds[3]
-
-        # # Round up and down to nearest dx
-        # x0 = x0 - (x0 % dx)
-        # x1 = x1 + (dx - x1 % dx)
-        # y0 = y0 - (y0 % dx)
-        # y1 = y1 + (dx - y1 % dx)
-
-        xx = np.arange(x0, x1, dx) + 0.5 * dx
-        yy = np.arange(y1, y0, -dx) - 0.5 * dx
-        ii = np.empty(
-            (
-                len(yy),
-                len(xx),
-            ),
-            dtype=np.uint32,
+        create_topobathy_tiles(
+            root=root,
+            region=region,
+            elevation_list=elevation_list,
+            data_catalog=data_catalog,
+            index_path=index_path,
+            zoom_range=zr,
+            z_range=z_range,
+            fmt=fmt,
+            write_html_viewer=write_html_viewer,
+            max_workers=max_workers,
+            logger=logger,
         )
 
-        # # Create empty ds
-        # ds = xr.Dataset(
-        #     {
-        #         "index": (["y", "x"], ii),
-        #     },
-        #     coords={
-        #         "x": xx,
-        #         "y": yy,
-        #     },
-        # )
-        # # Set no data value in ds
-        # ds["index"].attrs["_FillValue"] = nodata
+    def create_index_cog(
+        self,
+        filename: Union[str, Path],
+        filename_topobathy: Union[str, Path],
+    ) -> None:
+        """Write a COG raster mapping each pixel to a quadtree cell index.
 
-        # Go through refinement levels in grid
-        xx, yy = np.meshgrid(xx, yy)
-        indices = self.get_indices_at_points(xx, yy)
-        indices[np.where(indices == -999)] = nodata
+        Thin wrapper around
+        :py:func:`hydromt_sfincs.workflows.cog.make_index_cog`.
 
-        # Fill the array with indices
-        ii[:, :] = indices
-
-        # # Write first to netcdf
-        # ds.to_netcdf("index.nc")
-
-        # And now to cog (use -999 as the nodata value)
-        with rasterio.open(
-            filename,
-            "w",
-            driver="COG",
-            height=height,
-            width=width,
-            count=1,
-            dtype=ii.dtype,
-            crs=crs,
-            transform=transform,
-            nodata=nodata,
-            overview_resampling=Resampling.nearest,
-        ) as dst:
-            dst.write(ii, 1)
+        Parameters
+        ----------
+        filename : str or Path
+            Output COG file path.
+        filename_topobathy : str or Path
+            Reference topobathy COG whose grid / CRS define the output.
+        """
+        make_index_cog(
+            quadtree_grid=self,
+            filename=filename,
+            filename_topobathy=filename_topobathy,
+        )
 
 
-def binary_search(val_array, vals):
+def binary_search(val_array: np.ndarray, vals: np.ndarray) -> np.ndarray:
+    """Return the position of each ``vals`` entry within ``val_array``.
+
+    Entries that are not present in ``val_array`` are returned as ``-1``.
+    ``val_array`` must be sorted.
+
+    Parameters
+    ----------
+    val_array : np.ndarray
+        Sorted 1-D array to search within.
+    vals : np.ndarray
+        1-D array of values to locate.
+
+    Returns
+    -------
+    np.ndarray
+        1-D ``int`` array of the same length as ``vals`` holding the match
+        index into ``val_array``, or ``-1`` where no match exists.
+    """
     indx = np.searchsorted(val_array, vals)  # ind is size of vals
     not_ok = np.where(indx == len(val_array))[
         0
     ]  # size of vals, points that are out of bounds
-    indx[
-        np.where(indx == len(val_array))[0]
-    ] = 0  # Set to zero to avoid out of bounds error
+    indx[np.where(indx == len(val_array))[0]] = (
+        0  # Set to zero to avoid out of bounds error
+    )
     is_ok = np.where(val_array[indx] == vals)[0]  # size of vals
     indices = np.zeros(len(vals), dtype=int) - 1
     indices[is_ok] = indx[is_ok]

--- a/hydromt_sfincs/components/quadtree/quadtree.py
+++ b/hydromt_sfincs/components/quadtree/quadtree.py
@@ -537,7 +537,7 @@ class SfincsQuadtreeGrid(MeshComponent):
             agg = cvs.line(
                 self.datashader_dataframe, x=["x1", "x2"], y=["y1", "y2"], axis=1
             )
-            img = tf.shade(agg)
+            img = tf.shade(agg, cmap=color)
             path = os.path.dirname(file_name)
             if not path:
                 path = os.getcwd()

--- a/hydromt_sfincs/components/quadtree/quadtree_elevation.py
+++ b/hydromt_sfincs/components/quadtree/quadtree_elevation.py
@@ -1,9 +1,12 @@
 import logging
 import gc
+import os
 import time
 from typing import TYPE_CHECKING, List
 
 import numpy as np
+import pandas as pd
+from pyproj import Transformer
 from scipy.interpolate import RegularGridInterpolator
 import xarray as xr
 import xugrid as xu
@@ -15,6 +18,14 @@ from hydromt_sfincs.utils import make_regular_grid
 from hydromt_sfincs.workflows.merge import (
     merge_multi_dataarrays,
 )
+
+try:
+    import datashader as ds
+    import datashader.transfer_functions as tf
+    from datashader.utils import export_image
+    HAS_DATASHADER = True
+except ImportError:
+    HAS_DATASHADER = False
 
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
@@ -213,6 +224,180 @@ class SfincsQuadtreeElevation(MeshComponent):
         self.data["z"] = xu.UgridDataArray(
             xr.DataArray(data=zz, dims=[ugrid2d.face_dimension]), ugrid2d
         )
+
+    # ------------------------------------------------------------------
+    # Datashader overlay
+    # ------------------------------------------------------------------
+
+    def get_datashader_dataframe(self):
+        """Build a trimesh DataFrame for datashader rendering.
+
+        Creates vertices (4 corners per cell) and simplices (2 triangles
+        per cell) in EPSG:3857 for use with ``datashader.Canvas.trimesh()``.
+        """
+        if self.data is None or "z" not in self.data:
+            self.datashader_vertices = pd.DataFrame()
+            self.datashader_simplices = pd.DataFrame()
+            return
+
+        grid = self.data
+        xy = grid.grid.face_coordinates
+        z = grid["z"].values[:]
+        level = grid["level"].values[:] - 1  # 0-based
+        dx0 = grid.attrs["dx"]
+        dy0 = grid.attrs["dy"]
+        rotation = grid.attrs["rotation"]
+        cosrot = np.cos(np.radians(rotation))
+        sinrot = np.sin(np.radians(rotation))
+
+        valid = np.isfinite(z)
+        n_valid = np.sum(valid)
+        if n_valid == 0:
+            self.datashader_vertices = pd.DataFrame()
+            self.datashader_simplices = pd.DataFrame()
+            return
+
+        cx = xy[valid, 0]
+        cy = xy[valid, 1]
+        cz = z[valid]
+        clevel = level[valid]
+
+        hdx = (dx0 / 2.0 ** clevel) / 2.0
+        hdy = (dy0 / 2.0 ** clevel) / 2.0
+
+        dx_offsets = np.array([-1, 1, 1, -1], dtype=np.float64)
+        dy_offsets = np.array([-1, -1, 1, 1], dtype=np.float64)
+
+        local_x = hdx[:, None] * dx_offsets[None, :]
+        local_y = hdy[:, None] * dy_offsets[None, :]
+
+        vx = cx[:, None] + cosrot * local_x - sinrot * local_y
+        vy = cy[:, None] + sinrot * local_x + cosrot * local_y
+
+        vx_flat = vx.ravel()
+        vy_flat = vy.ravel()
+        vz_flat = np.repeat(cz, 4)
+
+        transformer = Transformer.from_crs(self.model.crs, 3857, always_xy=True)
+        vx_3857, vy_3857 = transformer.transform(vx_flat, vy_flat)
+
+        if self.model.crs.is_geographic and np.max(xy[:, 0]) > 180.0:
+            vx_3857[vx_3857 < 0] += 40075016.68557849
+
+        self.datashader_vertices = pd.DataFrame({
+            "x": vx_3857, "y": vy_3857, "z": vz_flat,
+        })
+
+        cell_idx = np.arange(n_valid, dtype=np.int32)
+        v_base = cell_idx * 4
+        t0 = np.column_stack([v_base, v_base + 1, v_base + 2])
+        t1 = np.column_stack([v_base, v_base + 2, v_base + 3])
+        tris = np.vstack([t0, t1])
+
+        self.datashader_simplices = pd.DataFrame({
+            "v0": tris[:, 0], "v1": tris[:, 1], "v2": tris[:, 2],
+        })
+
+    def clear_datashader_dataframe(self):
+        """Clear cached datashader data."""
+        self.datashader_vertices = pd.DataFrame()
+        self.datashader_simplices = pd.DataFrame()
+
+    def map_overlay(
+        self,
+        file_name,
+        xlim=None,
+        ylim=None,
+        cmap="gist_earth",
+        cmin=None,
+        cmax=None,
+        width=800,
+    ):
+        """Create a map overlay image of the bathymetry using datashader.
+
+        Parameters
+        ----------
+        file_name : str
+            Output image file name (without extension — .png is appended).
+        xlim : list
+            [lon_min, lon_max] in WGS84 degrees.
+        ylim : list
+            [lat_min, lat_max] in WGS84 degrees.
+        cmap : str or list
+            Matplotlib colormap name or list of hex colors.
+        cmin, cmax : float, optional
+            Color scale range. If None, auto-scaled from data.
+        width : int
+            Output image width in pixels.
+
+        Returns
+        -------
+        bool
+            True if the image was created successfully.
+        """
+        if not HAS_DATASHADER:
+            logger.warning("datashader is not installed.")
+            return False
+
+        if self.data is None or "z" not in self.data:
+            return False
+
+        try:
+            if not hasattr(self, "datashader_vertices") or self.datashader_vertices.empty:
+                self.get_datashader_dataframe()
+
+            if self.datashader_vertices.empty:
+                return False
+
+            transformer = Transformer.from_crs(4326, 3857, always_xy=True)
+            xl0, yl0 = transformer.transform(xlim[0], ylim[0])
+            xl1, yl1 = transformer.transform(xlim[1], ylim[1])
+            if xl0 > xl1:
+                xl1 += 40075016.68557849
+            x_range = (xl0, xl1)
+            y_range = (yl0, yl1)
+
+            ratio = (y_range[1] - y_range[0]) / (x_range[1] - x_range[0])
+            height = int(width * ratio)
+
+            cvs = ds.Canvas(
+                x_range=x_range, y_range=y_range,
+                plot_width=width, plot_height=height,
+            )
+
+            mesh = ds.utils.mesh(
+                self.datashader_vertices,
+                self.datashader_simplices,
+            )
+
+            agg = cvs.trimesh(
+                self.datashader_vertices,
+                self.datashader_simplices,
+                mesh=mesh,
+                agg=ds.mean("z"),
+                interp=False,
+            )
+
+            if isinstance(cmap, str):
+                from matplotlib import colormaps
+                cmap = colormaps[cmap]
+
+            span = None
+            if cmin is not None and cmax is not None:
+                span = (cmin, cmax)
+
+            img = tf.shade(agg, cmap=cmap, span=span, how="linear")
+
+            path = os.path.dirname(file_name)
+            if not path:
+                path = os.getcwd()
+            name = os.path.splitext(os.path.basename(file_name))[0]
+            export_image(img, name, export_path=path)
+            return True
+
+        except Exception as e:
+            logger.warning(f"map_overlay failed: {e}")
+            return False
 
 
 def interp2(x0, y0, z0, x1, y1, method="linear"):

--- a/hydromt_sfincs/components/quadtree/quadtree_elevation.py
+++ b/hydromt_sfincs/components/quadtree/quadtree_elevation.py
@@ -312,6 +312,7 @@ class SfincsQuadtreeElevation(MeshComponent):
         cmin=None,
         cmax=None,
         width=800,
+        **kwargs,
     ):
         """Create a map overlay image of the bathymetry using datashader.
 

--- a/hydromt_sfincs/components/quadtree/quadtree_elevation.py
+++ b/hydromt_sfincs/components/quadtree/quadtree_elevation.py
@@ -1,12 +1,9 @@
 import logging
 import gc
-import os
 import time
 from typing import TYPE_CHECKING, List
 
 import numpy as np
-import pandas as pd
-from pyproj import Transformer
 from scipy.interpolate import RegularGridInterpolator
 import xarray as xr
 import xugrid as xu
@@ -15,17 +12,10 @@ from hydromt import hydromt_step
 from hydromt.model.components import MeshComponent
 
 from hydromt_sfincs.utils import make_regular_grid
+from hydromt_sfincs.workflows.map_overlay import ElevationOverlay
 from hydromt_sfincs.workflows.merge import (
     merge_multi_dataarrays,
 )
-
-try:
-    import datashader as ds
-    import datashader.transfer_functions as tf
-    from datashader.utils import export_image
-    HAS_DATASHADER = True
-except ImportError:
-    HAS_DATASHADER = False
 
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
@@ -38,10 +28,12 @@ class SfincsQuadtreeElevation(MeshComponent):
         self,
         model: "SfincsModel",
     ):
-        # The data for the elevation is stored in the model.quadtree_grid.data["z"]
+        # The elevation data lives on model.quadtree_grid.data["z"];
+        # the renderer holds the only local state.
         super().__init__(
             model=model,
         )
+        self._overlay = ElevationOverlay()
 
     @property
     def data(self):
@@ -226,82 +218,12 @@ class SfincsQuadtreeElevation(MeshComponent):
         )
 
     # ------------------------------------------------------------------
-    # Datashader overlay
+    # Map overlay (delegates to ElevationOverlay in workflows.map_overlay)
     # ------------------------------------------------------------------
 
-    def get_datashader_dataframe(self):
-        """Build a trimesh DataFrame for datashader rendering.
-
-        Creates vertices (4 corners per cell) and simplices (2 triangles
-        per cell) in EPSG:3857 for use with ``datashader.Canvas.trimesh()``.
-        """
-        if self.data is None or "z" not in self.data:
-            self.datashader_vertices = pd.DataFrame()
-            self.datashader_simplices = pd.DataFrame()
-            return
-
-        grid = self.data
-        xy = grid.grid.face_coordinates
-        z = grid["z"].values[:]
-        level = grid["level"].values[:] - 1  # 0-based
-        dx0 = grid.attrs["dx"]
-        dy0 = grid.attrs["dy"]
-        rotation = grid.attrs["rotation"]
-        cosrot = np.cos(np.radians(rotation))
-        sinrot = np.sin(np.radians(rotation))
-
-        valid = np.isfinite(z)
-        n_valid = np.sum(valid)
-        if n_valid == 0:
-            self.datashader_vertices = pd.DataFrame()
-            self.datashader_simplices = pd.DataFrame()
-            return
-
-        cx = xy[valid, 0]
-        cy = xy[valid, 1]
-        cz = z[valid]
-        clevel = level[valid]
-
-        hdx = (dx0 / 2.0 ** clevel) / 2.0
-        hdy = (dy0 / 2.0 ** clevel) / 2.0
-
-        dx_offsets = np.array([-1, 1, 1, -1], dtype=np.float64)
-        dy_offsets = np.array([-1, -1, 1, 1], dtype=np.float64)
-
-        local_x = hdx[:, None] * dx_offsets[None, :]
-        local_y = hdy[:, None] * dy_offsets[None, :]
-
-        vx = cx[:, None] + cosrot * local_x - sinrot * local_y
-        vy = cy[:, None] + sinrot * local_x + cosrot * local_y
-
-        vx_flat = vx.ravel()
-        vy_flat = vy.ravel()
-        vz_flat = np.repeat(cz, 4)
-
-        transformer = Transformer.from_crs(self.model.crs, 3857, always_xy=True)
-        vx_3857, vy_3857 = transformer.transform(vx_flat, vy_flat)
-
-        if self.model.crs.is_geographic and np.max(xy[:, 0]) > 180.0:
-            vx_3857[vx_3857 < 0] += 40075016.68557849
-
-        self.datashader_vertices = pd.DataFrame({
-            "x": vx_3857, "y": vy_3857, "z": vz_flat,
-        })
-
-        cell_idx = np.arange(n_valid, dtype=np.int32)
-        v_base = cell_idx * 4
-        t0 = np.column_stack([v_base, v_base + 1, v_base + 2])
-        t1 = np.column_stack([v_base, v_base + 2, v_base + 3])
-        tris = np.vstack([t0, t1])
-
-        self.datashader_simplices = pd.DataFrame({
-            "v0": tris[:, 0], "v1": tris[:, 1], "v2": tris[:, 2],
-        })
-
-    def clear_datashader_dataframe(self):
-        """Clear cached datashader data."""
-        self.datashader_vertices = pd.DataFrame()
-        self.datashader_simplices = pd.DataFrame()
+    def clear_overlay(self) -> None:
+        """Invalidate the cached elevation-overlay trimesh."""
+        self._overlay.invalidate()
 
     def map_overlay(
         self,
@@ -311,94 +233,32 @@ class SfincsQuadtreeElevation(MeshComponent):
         cmap="gist_earth",
         cmin=None,
         cmax=None,
-        width=800,
+        width: int = 800,
         **kwargs,
-    ):
-        """Create a map overlay image of the bathymetry using datashader.
+    ) -> bool:
+        """Render a PNG elevation overlay.
 
-        Parameters
-        ----------
-        file_name : str
-            Output image file name (without extension — .png is appended).
-        xlim : list
-            [lon_min, lon_max] in WGS84 degrees.
-        ylim : list
-            [lat_min, lat_max] in WGS84 degrees.
-        cmap : str or list
-            Matplotlib colormap name or list of hex colors.
-        cmin, cmax : float, optional
-            Color scale range. If None, auto-scaled from data.
-        width : int
-            Output image width in pixels.
-
-        Returns
-        -------
-        bool
-            True if the image was created successfully.
+        One-line wrapper around
+        :py:class:`hydromt_sfincs.workflows.map_overlay.ElevationOverlay`.
         """
-        if not HAS_DATASHADER:
-            logger.warning("datashader is not installed.")
-            return False
-
         if self.data is None or "z" not in self.data:
             return False
-
-        try:
-            if not hasattr(self, "datashader_vertices") or self.datashader_vertices.empty:
-                self.get_datashader_dataframe()
-
-            if self.datashader_vertices.empty:
-                return False
-
-            transformer = Transformer.from_crs(4326, 3857, always_xy=True)
-            xl0, yl0 = transformer.transform(xlim[0], ylim[0])
-            xl1, yl1 = transformer.transform(xlim[1], ylim[1])
-            if xl0 > xl1:
-                xl1 += 40075016.68557849
-            x_range = (xl0, xl1)
-            y_range = (yl0, yl1)
-
-            ratio = (y_range[1] - y_range[0]) / (x_range[1] - x_range[0])
-            height = int(width * ratio)
-
-            cvs = ds.Canvas(
-                x_range=x_range, y_range=y_range,
-                plot_width=width, plot_height=height,
-            )
-
-            mesh = ds.utils.mesh(
-                self.datashader_vertices,
-                self.datashader_simplices,
-            )
-
-            agg = cvs.trimesh(
-                self.datashader_vertices,
-                self.datashader_simplices,
-                mesh=mesh,
-                agg=ds.mean("z"),
-                interp=False,
-            )
-
-            if isinstance(cmap, str):
-                from matplotlib import colormaps
-                cmap = colormaps[cmap]
-
-            span = None
-            if cmin is not None and cmax is not None:
-                span = (cmin, cmax)
-
-            img = tf.shade(agg, cmap=cmap, span=span, how="linear")
-
-            path = os.path.dirname(file_name)
-            if not path:
-                path = os.getcwd()
-            name = os.path.splitext(os.path.basename(file_name))[0]
-            export_image(img, name, export_path=path)
-            return True
-
-        except Exception as e:
-            logger.warning(f"map_overlay failed: {e}")
-            return False
+        return self._overlay.render(
+            face_xy=self.data.grid.face_coordinates,
+            z=self.data["z"].values[:],
+            level=self.data["level"].values[:],
+            dx0=self.data.attrs["dx"],
+            dy0=self.data.attrs["dy"],
+            rotation=self.data.attrs["rotation"],
+            source_crs=self.model.crs,
+            file_name=file_name,
+            xlim=xlim,
+            ylim=ylim,
+            cmap=cmap,
+            cmin=cmin,
+            cmax=cmax,
+            width=width,
+        )
 
 
 def interp2(x0, y0, z0, x1, y1, method="linear"):

--- a/hydromt_sfincs/components/quadtree/quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/quadtree_mask.py
@@ -729,6 +729,10 @@ class SfincsQuadtreeMask(ModelComponent):
             return False
         if len(self.model.quadtree_grid.data.data_vars) == 0:
             return False
+        # Skip when the mask variable this subclass renders isn't built
+        # yet (e.g. SnapWave mask before ``create`` has run).
+        if self._mask_variable not in self.model.quadtree_grid.data:
+            return False
         return self._overlay.render(
             x=self.face_coordinates[0][:],
             y=self.face_coordinates[1][:],

--- a/hydromt_sfincs/components/quadtree/quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/quadtree_mask.py
@@ -751,42 +751,36 @@ class SfincsQuadtreeMask(ModelComponent):
         file_name,
         xlim=None,
         ylim=None,
-        active_color="yellow",
-        boundary_color="red",
-        downstream_color="blue",
-        neumann_color="purple",
-        outflow_color="green",
+        colors=None,
         px=2,
         width=800,
+        **kwargs,
     ):
-        """Creates a map overlay image of the mask
+        """Create a map overlay image of the mask using datashader.
 
         Parameters
         ----------
         file_name : str
-            The file name of the image
-        xlim : list, optional
-            The x limits of the image
-        ylim : list, optional
-            The y limits of the image
-        active_color : str, optional
-            The color of the active cells
-        boundary_color : str, optional
-            The color of the boundary cells
-        outflow_color : str, optional
-            The color of the outflow cells
+            Output image file name.
+        xlim, ylim : list, optional
+            Geographic (lon/lat) extent of the image.
+        colors : dict, optional
+            Mapping of integer mask values to colour strings, e.g.
+            ``{1: "yellow", 2: "red", 3: "green"}``.  By default
+            ``{1: "yellow", 2: "red", 3: "green", 5: "purple", 6: "blue"}``.
         px : int, optional
-            The marker size in pixels
+            Marker radius in pixels, by default 2.
         width : int, optional
-            The width of the image in pixels
+            Output image width in pixels, by default 800.
 
         Returns
         -------
         bool
-            True if the image was created successfully, False otherwise
+            True if the image was created successfully, False otherwise.
         """
+        if colors is None:
+            colors = {1: "yellow", 2: "red", 3: "green", 5: "purple", 6: "blue"}
 
-        # check if datashader is available
         if not HAS_DATASHADER:
             logger.warning("Datashader is not available. Please install datashader.")
             return False
@@ -795,11 +789,9 @@ class SfincsQuadtreeMask(ModelComponent):
             return False
 
         try:
-            # Check if datashader dataframe is empty (maybe it was not made yet, or it was cleared)
             if self.datashader_dataframe.empty:
                 self.get_datashader_dataframe()
 
-            # If it is still empty (because there are no active cells), return False
             if self.datashader_dataframe.empty:
                 return False
 
@@ -817,33 +809,25 @@ class SfincsQuadtreeMask(ModelComponent):
                 x_range=xlim, y_range=ylim, plot_height=height, plot_width=width
             )
 
-            # Instead, we can create separate images for each mask and stack them
-            dfact = self.datashader_dataframe[self.datashader_dataframe["mask"] == 1]
-            dfbnd = self.datashader_dataframe[self.datashader_dataframe["mask"] == 2]
-            dfout = self.datashader_dataframe[self.datashader_dataframe["mask"] == 3]
-            dfneu = self.datashader_dataframe[self.datashader_dataframe["mask"] == 5]
-            dfdwn = self.datashader_dataframe[self.datashader_dataframe["mask"] == 6]
-            img_a = tf.shade(
-                tf.spread(cvs.points(dfact, "x", "y", ds.any()), px=px),
-                cmap=active_color,
-            )
-            img_b = tf.shade(
-                tf.spread(cvs.points(dfbnd, "x", "y", ds.any()), px=px),
-                cmap=boundary_color,
-            )
-            img_o = tf.shade(
-                tf.spread(cvs.points(dfout, "x", "y", ds.any()), px=px),
-                cmap=outflow_color,
-            )
-            img_n = tf.shade(
-                tf.spread(cvs.points(dfneu, "x", "y", ds.any()), px=px),
-                cmap=neumann_color,
-            )
-            img_d = tf.shade(
-                tf.spread(cvs.points(dfdwn, "x", "y", ds.any()), px=px),
-                cmap=downstream_color,
-            )
-            img = tf.stack(img_a, img_b, img_o, img_n, img_d)
+            images = []
+            for mask_val, color in colors.items():
+                df_sub = self.datashader_dataframe[
+                    self.datashader_dataframe["mask"] == mask_val
+                ]
+                if len(df_sub) > 0:
+                    images.append(
+                        tf.shade(
+                            tf.spread(cvs.points(df_sub, "x", "y", ds.any()), px=px),
+                            cmap=color,
+                        )
+                    )
+
+            if not images:
+                return False
+
+            img = images[0]
+            for im in images[1:]:
+                img = tf.stack(img, im)
 
             path = os.path.dirname(file_name)
             if not path:

--- a/hydromt_sfincs/components/quadtree/quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/quadtree_mask.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 import warnings
 from typing import TYPE_CHECKING, Union
@@ -11,24 +10,14 @@ import shapely
 import xarray as xr
 import xugrid as xu
 from matplotlib import path
-from pyproj import Transformer
 
 from hydromt import hydromt_step
 from hydromt.model.components import ModelComponent
 
 from hydromt_sfincs import utils
+from hydromt_sfincs.workflows.map_overlay import MaskOverlay
 
 np.warnings = warnings
-
-# optional dependency
-try:
-    import datashader as ds
-    import datashader.transfer_functions as tf
-    from datashader.utils import export_image
-
-    HAS_DATASHADER = True
-except ImportError:
-    HAS_DATASHADER = False
 
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
@@ -38,6 +27,10 @@ logger = logging.getLogger(f"hydromt.{__name__}")
 
 
 class SfincsQuadtreeMask(ModelComponent):
+    # Variable name (in model.quadtree_grid.data) that the overlay renderer
+    # samples. Subclasses (e.g. SnapWaveQuadtreeMask) override this.
+    _mask_variable: str = "mask"
+
     def __init__(
         self,
         model: "SfincsModel",
@@ -46,9 +39,9 @@ class SfincsQuadtreeMask(ModelComponent):
         super().__init__(
             model=model,
         )
-        # For plotting map overlay (This is the only data that is stored in the object!
-        # All other data is stored in the model.grid.data["mask"])
-        self.datashader_dataframe = pd.DataFrame()
+        # Lazy mask-overlay renderer (holds the only internal state; all
+        # mask data itself lives on model.quadtree_grid.data["mask"]).
+        self._overlay = MaskOverlay()
 
     @property
     def data(self):
@@ -105,7 +98,6 @@ class SfincsQuadtreeMask(ModelComponent):
         downstream_boundary_zmin: float = None,
         downstream_boundary_zmax: float = None,
         all_touched: bool = False,
-        update_datashader_dataframe=False,
     ):
         """Setup active model mask and add boundaries. Note that boundary types can only be set when polygons are provided.
 
@@ -222,9 +214,7 @@ class SfincsQuadtreeMask(ModelComponent):
                 all_touched=all_touched,
             )
 
-        if update_datashader_dataframe:
-            # For use in DelftDashboard
-            self.get_datashader_dataframe()
+        self._overlay.invalidate()
 
     @hydromt_step
     def create_active(
@@ -712,39 +702,13 @@ class SfincsQuadtreeMask(ModelComponent):
 
         return gdf
 
-    def get_datashader_dataframe(self, variable="mask"):
-        """Sets the datashader dataframe for plotting"""
-        # Create a dataframe with points elements
-        # Coordinates of cell centers
-        x = self.face_coordinates[0][:]
-        y = self.face_coordinates[1][:]
-        # Check if grid crosses the dateline
-        cross_dateline = False
-        if self.model.crs.is_geographic:
-            if np.max(x) > 180.0:
-                cross_dateline = True
-        mask = self.model.quadtree_grid.data[variable].values[:]
-        # Get rid of cells with mask = 0
-        iok = np.where(mask > 0)
-        x = x[iok]
-        y = y[iok]
-        mask = mask[iok]
-        if np.size(x) == 0:
-            # Return empty dataframe
-            self.datashader_dataframe = pd.DataFrame()
-            return
-        # Transform all to 3857 (web mercator)
-        transformer = Transformer.from_crs(self.model.crs, 3857, always_xy=True)
-        x, y = transformer.transform(x, y)
-        if cross_dateline:
-            x[x < 0] += 40075016.68557849
+    def clear_overlay(self) -> None:
+        """Invalidate the cached mask-overlay dataframe.
 
-        self.datashader_dataframe = pd.DataFrame(dict(x=x, y=y, mask=mask))
-
-    def clear_datashader_dataframe(self):
-        """Clears the datashader dataframe"""
-        # Called in model.grid.build method
-        self.datashader_dataframe = pd.DataFrame()
+        Call this whenever the grid or mask is rebuilt so the next
+        :py:meth:`map_overlay` render picks up fresh values.
+        """
+        self._overlay.invalidate()
 
     def map_overlay(
         self,
@@ -752,94 +716,31 @@ class SfincsQuadtreeMask(ModelComponent):
         xlim=None,
         ylim=None,
         colors=None,
-        px=2,
-        width=800,
+        px: int = 2,
+        width: int = 800,
         **kwargs,
-    ):
-        """Create a map overlay image of the mask using datashader.
+    ) -> bool:
+        """Render a PNG mask overlay.
 
-        Parameters
-        ----------
-        file_name : str
-            Output image file name.
-        xlim, ylim : list, optional
-            Geographic (lon/lat) extent of the image.
-        colors : dict, optional
-            Mapping of integer mask values to colour strings, e.g.
-            ``{1: "yellow", 2: "red", 3: "green"}``.  By default
-            ``{1: "yellow", 2: "red", 3: "green", 5: "purple", 6: "blue"}``.
-        px : int, optional
-            Marker radius in pixels, by default 2.
-        width : int, optional
-            Output image width in pixels, by default 800.
-
-        Returns
-        -------
-        bool
-            True if the image was created successfully, False otherwise.
+        One-line wrapper around
+        :py:class:`hydromt_sfincs.workflows.map_overlay.MaskOverlay`.
         """
-        if colors is None:
-            colors = {1: "yellow", 2: "red", 3: "green", 5: "purple", 6: "blue"}
-
-        if not HAS_DATASHADER:
-            logger.warning("Datashader is not available. Please install datashader.")
+        if self.model.quadtree_grid.data is None:
             return False
-
         if len(self.model.quadtree_grid.data.data_vars) == 0:
             return False
-
-        try:
-            if self.datashader_dataframe.empty:
-                self.get_datashader_dataframe()
-
-            if self.datashader_dataframe.empty:
-                return False
-
-            transformer = Transformer.from_crs(4326, 3857, always_xy=True)
-            xl0, yl0 = transformer.transform(xlim[0], ylim[0])
-            xl1, yl1 = transformer.transform(xlim[1], ylim[1])
-            if xl0 > xl1:
-                xl1 += 40075016.68557849
-            xlim = [xl0, xl1]
-            ylim = [yl0, yl1]
-            ratio = (ylim[1] - ylim[0]) / (xlim[1] - xlim[0])
-            height = int(width * ratio)
-
-            cvs = ds.Canvas(
-                x_range=xlim, y_range=ylim, plot_height=height, plot_width=width
-            )
-
-            images = []
-            for mask_val, color in colors.items():
-                df_sub = self.datashader_dataframe[
-                    self.datashader_dataframe["mask"] == mask_val
-                ]
-                if len(df_sub) > 0:
-                    images.append(
-                        tf.shade(
-                            tf.spread(cvs.points(df_sub, "x", "y", ds.any()), px=px),
-                            cmap=color,
-                        )
-                    )
-
-            if not images:
-                return False
-
-            img = images[0]
-            for im in images[1:]:
-                img = tf.stack(img, im)
-
-            path = os.path.dirname(file_name)
-            if not path:
-                path = os.getcwd()
-            name = os.path.basename(file_name)
-            name = os.path.splitext(name)[0]
-            export_image(img, name, export_path=path)
-            return True
-
-        except Exception as e:
-            print(e)
-            return False
+        return self._overlay.render(
+            x=self.face_coordinates[0][:],
+            y=self.face_coordinates[1][:],
+            mask=self.model.quadtree_grid.data[self._mask_variable].values[:],
+            source_crs=self.model.crs,
+            file_name=file_name,
+            xlim=xlim,
+            ylim=ylim,
+            colors=colors,
+            px=px,
+            width=width,
+        )
 
     def _find_boundary_cells(self, varname):
         mu = self.data["mu"].values[:]

--- a/hydromt_sfincs/components/quadtree/quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/quadtree_mask.py
@@ -27,7 +27,6 @@ try:
     from datashader.utils import export_image
 
     HAS_DATASHADER = True
-
 except ImportError:
     HAS_DATASHADER = False
 
@@ -47,7 +46,8 @@ class SfincsQuadtreeMask(ModelComponent):
         super().__init__(
             model=model,
         )
-        # For plotting map overlay (This is the only data that is stored in the object! All other data is stored in the model.grid.data["mask"])
+        # For plotting map overlay (This is the only data that is stored in the object!
+        # All other data is stored in the model.grid.data["mask"])
         self.datashader_dataframe = pd.DataFrame()
 
     @property
@@ -62,6 +62,15 @@ class SfincsQuadtreeMask(ModelComponent):
     @property
     def face_coordinates(self):
         return self.model.quadtree_grid.face_coordinates
+
+    @property
+    def has_open_boundaries(self):
+        """Returns True if mask contains open boundaries (mask = 2)"""
+        if "mask" not in self.data:
+            return False
+
+        mask = self.data["mask"]
+        return (mask == 2).any().item()
 
     def read(self):
         # The mask values are read when the quadtree grid is read
@@ -130,14 +139,33 @@ class SfincsQuadtreeMask(ModelComponent):
             include_polygon = None
         if isinstance(exclude_polygon, gpd.GeoDataFrame) and exclude_polygon.empty:
             exclude_polygon = None
-        if isinstance(open_boundary_polygon, gpd.GeoDataFrame) and open_boundary_polygon.empty:
+        if (
+            isinstance(open_boundary_polygon, gpd.GeoDataFrame)
+            and open_boundary_polygon.empty
+        ):
             open_boundary_polygon = None
-        if isinstance(outflow_boundary_polygon, gpd.GeoDataFrame) and outflow_boundary_polygon.empty:
+        if (
+            isinstance(outflow_boundary_polygon, gpd.GeoDataFrame)
+            and outflow_boundary_polygon.empty
+        ):
             outflow_boundary_polygon = None
-        if isinstance(neumann_boundary_polygon, gpd.GeoDataFrame) and neumann_boundary_polygon.empty:
+        if (
+            isinstance(neumann_boundary_polygon, gpd.GeoDataFrame)
+            and neumann_boundary_polygon.empty
+        ):
             neumann_boundary_polygon = None
-        if isinstance(downstream_boundary_polygon, gpd.GeoDataFrame) and downstream_boundary_polygon.empty:
+        if (
+            isinstance(downstream_boundary_polygon, gpd.GeoDataFrame)
+            and downstream_boundary_polygon.empty
+        ):
             downstream_boundary_polygon = None
+
+        if model == "sfincs":
+            open_btype = "waterlevel"
+        elif model == "snapwave":
+            open_btype = "waves"
+        else:
+            raise ValueError("Model must be either 'sfincs' or 'snapwave'!")
 
         # Create active model cells
         self.create_active(
@@ -157,7 +185,7 @@ class SfincsQuadtreeMask(ModelComponent):
         if open_boundary_polygon is not None:
             self.create_boundary(
                 model=model,
-                btype="waterlevel",
+                btype=open_btype,
                 include_polygon=open_boundary_polygon,
                 include_zmin=open_boundary_zmin,
                 include_zmax=open_boundary_zmax,
@@ -596,10 +624,9 @@ class SfincsQuadtreeMask(ModelComponent):
                     uda_include = np.logical_and(uda_include, uda_dep <= include_zmax)
             bounds = np.logical_and(bounds, uda_include)
             if not bounds.any():
-                # This should not be an error. Better to just give a warning.                
+                # This should not be an error. Better to just give a warning.
                 # raise ValueError("No mask boundary cells found within include polygon!")
                 logger.warning("No mask boundary cells found within polygon!")
-            
 
         if gdf_exclude is not None:
             uda_exclude = (
@@ -685,17 +712,7 @@ class SfincsQuadtreeMask(ModelComponent):
 
         return gdf
 
-    def has_open_boundaries(self):
-        """Returns True if mask contains open boundaries (mask = 2)"""
-        mask = self.model.quadtree_grid.data["mask"]
-        if mask is None:
-            return False
-        if np.any(mask == 2):
-            return True
-        else:
-            return False
-
-    def get_datashader_dataframe(self):
+    def get_datashader_dataframe(self, variable="mask"):
         """Sets the datashader dataframe for plotting"""
         # Create a dataframe with points elements
         # Coordinates of cell centers
@@ -706,7 +723,7 @@ class SfincsQuadtreeMask(ModelComponent):
         if self.model.crs.is_geographic:
             if np.max(x) > 180.0:
                 cross_dateline = True
-        mask = self.model.quadtree_grid.data["mask"].values[:]
+        mask = self.model.quadtree_grid.data[variable].values[:]
         # Get rid of cells with mask = 0
         iok = np.where(mask > 0)
         x = x[iok]
@@ -774,8 +791,7 @@ class SfincsQuadtreeMask(ModelComponent):
             logger.warning("Datashader is not available. Please install datashader.")
             return False
 
-        if self.model.quadtree_grid.data is None:
-            # No grid or mask points
+        if len(self.model.quadtree_grid.data.data_vars) == 0:
             return False
 
         try:

--- a/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
@@ -1,18 +1,17 @@
 import logging
 import os
+from pathlib import Path
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import shapely
-import xarray as xr
-import xugrid as xu
-from matplotlib import path
 from pyproj import Transformer
 
-from hydromt.model.components import ModelComponent
+from hydromt import hydromt_step
+
+from hydromt_sfincs.components.quadtree import SfincsQuadtreeMask
 
 np.warnings = warnings
 
@@ -34,472 +33,234 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class SnapWaveQuadtreeMask(ModelComponent):
+class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
     def __init__(
         self,
         model: "SfincsModel",
     ):
-        # The data for the mask is stored in the model.quadtree_grid.data["mask"] array
-        self.data = None
         super().__init__(
             model=model,
         )
-        # For plotting map overlay (This is the only data that is stored in the object! All other data is stored in the model.grid.data["mask"])
+        # For plotting map overlay (This is the only data that is stored in the object!
+        # All other data is stored in the model.grid.data["mask"])
         self.datashader_dataframe = pd.DataFrame()
-
-    def read(self):
-        # The mask values are read when the quadtree grid is read
-        pass
-
-    def write(self):
-        # The mask values are written when the quadtree grid is written
-        pass
-
-    # Is this not supposed to be called "create"?
-    def build(
-        self,
-        zmin=99999.0,
-        zmax=-99999.0,
-        include_polygon=None,
-        exclude_polygon=None,
-        open_boundary_polygon=None,
-        neumann_boundary_polygon=None,
-        include_zmin=-99999.0,
-        include_zmax=99999.0,
-        exclude_zmin=-99999.0,
-        exclude_zmax=99999.0,
-        open_boundary_zmin=-99999.0,
-        open_boundary_zmax=99999.0,
-        neumann_boundary_zmin=-99999.0,
-        neumann_boundary_zmax=99999.0,
-        update_datashader_dataframe=False,
-        quiet=True,
-    ):
-        if not quiet:
-            print("Building mask ...")
-
-        nr_cells = self.model.quadtree_grid.data.sizes["mesh2d_nFaces"]
-
-        mask = np.zeros(nr_cells, dtype=np.int8)
-        x, y = self.model.quadtree_grid.face_coordinates
-        z = self.model.quadtree_grid.data["z"].values[:]
-
-        # Indices are 1-based in SFINCS so subtract 1 for python 0-based indexing
-        mu = self.model.quadtree_grid.data["mu"].values[:]
-        mu1 = self.model.quadtree_grid.data["mu1"].values[:] - 1
-        mu2 = self.model.quadtree_grid.data["mu2"].values[:] - 1
-        nu = self.model.quadtree_grid.data["nu"].values[:]
-        nu1 = self.model.quadtree_grid.data["nu1"].values[:] - 1
-        nu2 = self.model.quadtree_grid.data["nu2"].values[:] - 1
-        md = self.model.quadtree_grid.data["md"].values[:]
-        md1 = self.model.quadtree_grid.data["md1"].values[:] - 1
-        md2 = self.model.quadtree_grid.data["md2"].values[:] - 1
-        nd = self.model.quadtree_grid.data["nd"].values[:]
-        nd1 = self.model.quadtree_grid.data["nd1"].values[:] - 1
-        nd2 = self.model.quadtree_grid.data["nd2"].values[:] - 1
-
-        if zmin >= zmax:
-            # Do not include any points initially
-            if include_polygon is None:
-                print(
-                    "WARNING: Entire mask set to zeros! Please ensure zmax is greater than zmin, or provide include polygon(s) !"
-                )
-                return
-        else:
-            if z is not None:
-                # Set initial mask based on zmin and zmax
-                iok = np.where((z >= zmin) & (z <= zmax))
-                mask[iok] = 1
-            else:
-                print(
-                    "WARNING: Entire mask set to zeros! No depth values found on grid."
-                )
-
-        # Include polygons
-        if include_polygon is not None:
-            for ip, polygon in include_polygon.iterrows():
-                inpol = inpolygon(x, y, polygon["geometry"])
-                iok = np.where((inpol) & (z >= include_zmin) & (z <= include_zmax))
-                mask[iok] = 1
-
-        # Exclude polygons
-        if exclude_polygon is not None:
-            for ip, polygon in exclude_polygon.iterrows():
-                inpol = inpolygon(x, y, polygon["geometry"])
-                iok = np.where((inpol) & (z >= exclude_zmin) & (z <= exclude_zmax))
-                mask[iok] = 0
-
-        # Open boundary polygons
-        if open_boundary_polygon is not None:
-            for ip, polygon in open_boundary_polygon.iterrows():
-                inpol = inpolygon(x, y, polygon["geometry"])
-                # Only consider points that are:
-                # 1) Inside the polygon
-                # 2) Have a mask > 0
-                # 3) z>=zmin
-                # 4) z<=zmax
-                iok = np.where(
-                    (inpol)
-                    & (mask > 0)
-                    & (z >= open_boundary_zmin)
-                    & (z <= open_boundary_zmax)
-                )
-                for ic in iok[0]:
-                    okay = False
-                    # Check neighbors, cell must have at least one inactive neighbor
-                    # Left
-                    if md[ic] <= 0:
-                        # Coarser or equal to the left
-                        if md1[ic] >= 0:
-                            # Cell has neighbor to the left
-                            if mask[md1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                    else:
-                        # Finer to the left
-                        if md1[ic] >= 0:
-                            # Cell has neighbor to the left
-                            if mask[md1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                        if md2[ic] >= 0:
-                            # Cell has neighbor to the left
-                            if mask[md2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-
-                    # Below
-                    if nd[ic] <= 0:
-                        # Coarser or equal below
-                        if nd1[ic] >= 0:
-                            # Cell has neighbor below
-                            if mask[nd1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                    else:
-                        # Finer below
-                        if nd1[ic] >= 0:
-                            # Cell has neighbor below
-                            if mask[nd1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                        if nd2[ic] >= 0:
-                            # Cell has neighbor below
-                            if mask[nd2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-
-                    # Right
-                    if mu[ic] <= 0:
-                        # Coarser or equal to the right
-                        if mu1[ic] >= 0:
-                            # Cell has neighbor to the right
-                            if mask[mu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                    else:
-                        # Finer to the left
-                        if mu1[ic] >= 0:
-                            # Cell has neighbor to the right
-                            if mask[mu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                        if mu2[ic] >= 0:
-                            # Cell has neighbor to the right
-                            if mask[mu2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-
-                    # Above
-                    if nu[ic] <= 0:
-                        # Coarser or equal above
-                        if nu1[ic] >= 0:
-                            # Cell has neighbor above
-                            if mask[nu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                    else:
-                        # Finer below
-                        if nu1[ic] >= 0:
-                            # Cell has neighbor above
-                            if mask[nu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-                        if nu2[ic] >= 0:
-                            # Cell has neighbor above
-                            if mask[nu2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 2
-                            okay = True
-
-                    if okay:
-                        mask[ic] = 2
-
-        # Outflow boundary polygons
-        if neumann_boundary_polygon is not None:
-            for ip, polygon in neumann_boundary_polygon.iterrows():
-                inpol = inpolygon(x, y, polygon["geometry"])
-                # Only consider points that are:
-                # 1) Inside the polygon
-                # 2) Have a mask > 0
-                # 3) z>=zmin
-                # 4) z<=zmax
-                iok = np.where(
-                    (inpol)
-                    & (mask > 0)
-                    & (z >= neumann_boundary_zmin)
-                    & (z <= neumann_boundary_zmax)
-                )
-                for ic in iok[0]:
-                    okay = False
-                    # Check neighbors, cell must have at least one inactive neighbor
-                    # Left
-                    if md[ic] <= 0:
-                        # Coarser or equal to the left
-                        if md1[ic] >= 0:
-                            # Cell has neighbor to the left
-                            if mask[md1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                    else:
-                        # Finer to the left
-                        if md1[ic] >= 0:
-                            # Cell has neighbor to the left
-                            if mask[md1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                        if md2[ic] >= 0:
-                            # Cell has neighbor to the left
-                            if mask[md2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-
-                    # Below
-                    if nd[ic] <= 0:
-                        # Coarser or equal below
-                        if nd1[ic] >= 0:
-                            # Cell has neighbor below
-                            if mask[nd1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                    else:
-                        # Finer below
-                        if nd1[ic] >= 0:
-                            # Cell has neighbor below
-                            if mask[nd1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                        if nd2[ic] >= 0:
-                            # Cell has neighbor below
-                            if mask[nd2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-
-                    # Right
-                    if mu[ic] <= 0:
-                        # Coarser or equal to the right
-                        if mu1[ic] >= 0:
-                            # Cell has neighbor to the right
-                            if mask[mu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                    else:
-                        # Finer to the left
-                        if mu1[ic] >= 0:
-                            # Cell has neighbor to the right
-                            if mask[mu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                        if mu2[ic] >= 0:
-                            # Cell has neighbor to the right
-                            if mask[mu2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-
-                    # Above
-                    if nu[ic] <= 0:
-                        # Coarser or equal above
-                        if nu1[ic] >= 0:
-                            # Cell has neighbor above
-                            if mask[nu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                    else:
-                        # Finer below
-                        if nu1[ic] >= 0:
-                            # Cell has neighbor above
-                            if mask[nu1[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                        if nu2[ic] >= 0:
-                            # Cell has neighbor above
-                            if mask[nu2[ic]] == 0:
-                                # And it's inactive
-                                okay = True
-                        else:
-                            # No neighbor, so set mask = 3
-                            okay = True
-                    if okay:
-                        mask[ic] = 3
-
-        # Now add the data arrays
-        ugrid2d = self.model.quadtree_grid.data.grid
-        self.model.quadtree_grid.data["snapwave_mask"] = xu.UgridDataArray(
-            xr.DataArray(data=mask, dims=[ugrid2d.face_dimension]), ugrid2d
-        )
-
-        if update_datashader_dataframe:
-            # For use in DelftDashboard
-            self.get_datashader_dataframe()
-
-    def to_gdf(self, option="all"):
-        """Returns a geodataframe with points for each cell in the mask"""
-
-        nr_cells = self.model.quadtree_grid.data.sizes["mesh2d_nFaces"]
-
-        if nr_cells == 0:
-            # Return empty geodataframe
-            return gpd.GeoDataFrame()
-        xz, yz = self.model.quadtree_grid.face_coordinates()
-        mask = self.model.quadtree_grid.data["snapwave_mask"]
-        gdf_list = []
-        okay = np.zeros(mask.shape, dtype=int)
-        if option == "all":
-            iok = np.where((mask > 0))
-        elif option == "include":
-            iok = np.where((mask == 1))
-        elif option == "open":
-            iok = np.where((mask == 2))
-        elif option == "outflow":
-            iok = np.where((mask == 3))
-        else:
-            iok = np.where((mask > -999))
-        okay[iok] = 1
-        for icel in range(nr_cells):
-            if okay[icel] == 1:
-                point = shapely.geometry.Point(xz[icel], yz[icel])
-                d = {"geometry": point}
-                gdf_list.append(d)
-
-        if gdf_list:
-            gdf = gpd.GeoDataFrame(gdf_list, crs=self.model.crs)
-        else:
-            # Cannot set crs of gdf with empty list
-            gdf = gpd.GeoDataFrame(gdf_list)
-
-        return gdf
 
     @property
     def has_open_boundaries(self):
         """Returns True if mask contains open boundaries (mask = 2)"""
-        mask = self.model.quadtree_grid.data["snapwave_mask"]
-        if mask is None:
-            return False
-        if np.any(mask == 2):
-            return True
-        else:
+        if "snapwave_mask" not in self.data:
             return False
 
-    def get_datashader_dataframe(self):
+        mask = self.data["snapwave_mask"]
+        return (mask == 2).any().item()
+
+    @hydromt_step
+    def create(
+        self,
+        zmin: float = None,
+        zmax: float = None,
+        include_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        include_zmin: float = None,
+        include_zmax: float = None,
+        exclude_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        exclude_zmin: float = None,
+        exclude_zmax: float = None,
+        open_boundary_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        open_boundary_zmin: float = None,
+        open_boundary_zmax: float = None,
+        neumann_boundary_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        neumann_boundary_zmin: float = None,
+        neumann_boundary_zmax: float = None,
+        all_touched: bool = False,
+        update_datashader_dataframe=False,
+    ):
+        """Setup active model snapwave mask and add boundaries. Note that boundary types can only be set when polygons are provided.
+
+        Parameters
+        ----------
+        model : str, optional
+            Model type, either 'sfincs' (default) or 'snapwave', for which the mask will be created.
+        zmin, zmax : float, optional
+            Minimum and maximum elevation thresholds for active model cells.
+        include_polygon, exclude_polygon: str, Path, gpd.GeoDataFrame, optional
+            Path or data source name of polygons to include/exclude from the active model domain.
+            Note that include (second last) and exclude (last) areas are processed after other critera,
+            i.e. `zmin`, `zmax` and thus overrule these criteria for active model cells.
+        include_zmin, include_zmax: float, optional
+            Minimum and maximum elevation thresholds for included model cells.
+        exclude_zmin, exclude_zmax: float, optional
+            Minimum and maximum elevation thresholds for excluded model cells.
+        open_boundary_polygon, neumann_boundary_polygon: str, Path, gpd.GeoDataFrame, optional
+            Path or data source name for geometries with areas to include as open boundary or neumann boundary.
+            For each polygon, also the minimum and maximum elevation thresholds can be specified using the corresponding `*_zmin` and `*_zmax` arguments.
+
+        See also:
+        ---------
+        * `create_active` method to setup active model cells
+        * `create_boundary` method to setup boundary cells of a specific type
+
+        """
+        super().create(
+            model="snapwave",
+            zmin=zmin,
+            zmax=zmax,
+            include_polygon=include_polygon,
+            include_zmin=include_zmin,
+            include_zmax=include_zmax,
+            exclude_polygon=exclude_polygon,
+            exclude_zmin=exclude_zmin,
+            exclude_zmax=exclude_zmax,
+            open_boundary_polygon=open_boundary_polygon,
+            open_boundary_zmin=open_boundary_zmin,
+            open_boundary_zmax=open_boundary_zmax,
+            neumann_boundary_polygon=neumann_boundary_polygon,
+            neumann_boundary_zmin=neumann_boundary_zmin,
+            neumann_boundary_zmax=neumann_boundary_zmax,
+            all_touched=all_touched,
+            update_datashader_dataframe=update_datashader_dataframe,
+        )
+
+    @hydromt_step
+    def create_active(
+        self,
+        zmin: float = None,
+        zmax: float = None,
+        include_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        include_zmin: float = None,
+        include_zmax: float = None,
+        exclude_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        exclude_zmin: float = None,
+        exclude_zmax: float = None,
+        all_touched: bool = False,
+        reset_mask: bool = True,
+        copy_sfincsmask: bool = False,
+    ):
+        """Setup active model cells.
+
+        The Snapwave model mask defines inactive (msk=0), active (msk=1), and wave boundary (msk=2)
+        cells. This method sets the active and inactive cells.
+
+        Active model cells are based on a region and cells with valid elevation (i.e. not nodata),
+        optionally bounded by areas inside the include geomtries, outside the exclude geomtries,
+        larger or equal than a minimum elevation threshhold and smaller or equal than a
+        maximum elevation threshhold.
+        All conditions are combined using a logical AND operation.
+
+        Adds layer to quadtree grid:
+
+        * **snapwave_mask** map: model mask [-]
+
+        Parameters
+        ----------
+        zmin, zmax : float, optional
+            Minimum and maximum elevation thresholds for active model cells.
+        include_polygon, exclude_polygon: str, Path, gpd.GeoDataFrame, optional
+            Path or data source name of polygons to include/exclude from the active model domain.
+            Note that include (second last) and exclude (last) areas are processed after other critera,
+            i.e. `zmin`, `zmax` and thus overrule these criteria for active model cells.
+        all_touched: bool, optional
+            if True (default) include (or exclude) a cell in the mask if it touches any of the
+            include (or exclude) geometries. If False, include a cell only if its center is
+            within one of the shapes, or if it is selected by Bresenham's line algorithm.
+        reset_mask: bool, optional
+            If True, reset existing mask before creating new active model cells.
+        copy_sfincsmask: bool, optional
+            If True, ccopy the SFINCS mask to the SnapWave mask.
+        """
+
+        super().create_active(
+            model="snapwave",
+            zmin=zmin,
+            zmax=zmax,
+            include_polygon=include_polygon,
+            include_zmin=include_zmin,
+            include_zmax=include_zmax,
+            exclude_polygon=exclude_polygon,
+            exclude_zmin=exclude_zmin,
+            exclude_zmax=exclude_zmax,
+            all_touched=all_touched,
+            reset_mask=reset_mask,
+            copy_sfincsmask=copy_sfincsmask,
+        )
+
+    @hydromt_step
+    def create_boundary(
+        self,
+        btype: str = "waves",
+        zmin: float = None,
+        zmax: float = None,
+        include_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        include_zmin: float = None,
+        include_zmax: float = None,
+        include_polygon_buffer: int = 0,
+        exclude_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
+        exclude_zmin: float = None,
+        exclude_zmax: float = None,
+        all_touched: bool = True,
+        reset_bounds: bool = True,
+        copy_sfincsmask: bool = False,
+        connectivity: int = 8,
+    ):
+        """Set boundary cells in the model mask.
+
+        The Snapwave model mask defines inactive (mask=0), active (mask=1), wave boundary (mask=2)
+        and neumann boundary (mask=3) cells. Active cells set using the `create_active` method,
+        while this method sets the different types of boundary cells, see `btype` argument.
+
+        Boundary cells at the edge of the active model domain,
+        optionally bounded by areas inside the include geomtries, outside the exclude geomtries,
+        larger or equal than a minimum elevation threshhold and smaller or equal than a
+        maximum elevation threshhold. All conditions are combined using a logical AND operation.
+
+        Updates snapwave mask layer in quadtree grid:
+
+        * **snapwave_mask** map: model mask [-]
+
+        Parameters
+        ----------
+        btype: str, optional
+            Boundary type {'waves', 'neumann'}, by default 'waves'.
+        zmin, zmax : float, optional
+            Minimum and maximum elevation thresholds for all boundary cells.
+        include_polygon, exclude_polygon: str, Path, gpd.GeoDataFrame, optional
+            Path or data source name for geometries with areas to include/exclude from
+            the model boundary. These can be combined with `include_zmin` and `include_zmax` to
+            further refine the selection of cells within the polygons.
+        reset_bounds: bool, optional
+            If True, reset existing boundary cells of the selected boundary
+            type (`btype`) before setting new boundary cells, by default False.
+        all_touched: bool, optional
+            if True (default) include (or exclude) a cell in the mask if it touches any of the
+            include (or exclude) geometries. If False, include a cell only if its center is
+            within one of the shapes, or if it is selected by Bresenham's line algorithm.
+        connectivity, {4, 8}:
+            The connectivity used to detect the model edge, if 4 only horizontal and vertical
+            connections are used, if 8 (default) also diagonal connections.
+        """
+        super().create_boundary(
+            model="snapwave",
+            btype=btype,
+            zmin=zmin,
+            zmax=zmax,
+            include_polygon=include_polygon,
+            include_zmin=include_zmin,
+            include_zmax=include_zmax,
+            include_polygon_buffer=include_polygon_buffer,
+            exclude_polygon=exclude_polygon,
+            exclude_zmin=exclude_zmin,
+            exclude_zmax=exclude_zmax,
+            all_touched=all_touched,
+            reset_bounds=reset_bounds,
+            copy_sfincsmask=copy_sfincsmask,
+            connectivity=connectivity,
+        )
+
+    def get_datashader_dataframe(self, variable="snapwave_mask"):
         """Sets the datashader dataframe for plotting"""
-        # Create a dataframe with points elements
-        # Coordinates of cell centers
-        x = self.model.quadtree_grid.data.grid.face_coordinates[:, 0]
-        y = self.model.quadtree_grid.data.grid.face_coordinates[:, 1]
-        # Check if grid crosses the dateline
-        cross_dateline = False
-        if self.model.crs.is_geographic:
-            if np.max(x) > 180.0:
-                cross_dateline = True
-        mask = self.model.quadtree_grid.data["snapwave_mask"].values[:]
-        # Get rid of cells with mask = 0
-        iok = np.where(mask > 0)
-        x = x[iok]
-        y = y[iok]
-        mask = mask[iok]
-        if np.size(x) == 0:
-            # Return empty dataframe
-            self.datashader_dataframe = pd.DataFrame()
-            return
-        # Transform all to 3857 (web mercator)
-        transformer = Transformer.from_crs(self.model.crs, 3857, always_xy=True)
-        x, y = transformer.transform(x, y)
-        if cross_dateline:
-            x[x < 0] += 40075016.68557849
-
-        self.datashader_dataframe = pd.DataFrame(dict(x=x, y=y, mask=mask))
+        super().get_datashader_dataframe(variable=variable)
 
     def clear_datashader_dataframe(self):
         """Clears the datashader dataframe"""
-        # Called in model.grid.build method
         self.datashader_dataframe = pd.DataFrame()
 
     def map_overlay(
@@ -545,8 +306,7 @@ class SnapWaveQuadtreeMask(ModelComponent):
             logger.warning("Datashader is not available. Please install datashader.")
             return False
 
-        if self.model.quadtree_grid.data is None:
-            # No grid or mask points
+        if len(self.model.quadtree_grid.data.data_vars) == 0:
             return False
 
         try:
@@ -573,9 +333,15 @@ class SnapWaveQuadtreeMask(ModelComponent):
             )
 
             # Instead, we can create separate images for each mask and stack them
-            dfact = self.datashader_dataframe[self.datashader_dataframe["mask"] == 1]
-            dfbnd = self.datashader_dataframe[self.datashader_dataframe["mask"] == 2]
-            dfout = self.datashader_dataframe[self.datashader_dataframe["mask"] == 3]
+            dfact = self.datashader_dataframe[
+                self.datashader_dataframe["snapwave_mask"] == 1
+            ]
+            dfbnd = self.datashader_dataframe[
+                self.datashader_dataframe["snapwave_mask"] == 2
+            ]
+            dfout = self.datashader_dataframe[
+                self.datashader_dataframe["snapwave_mask"] == 3
+            ]
             img_a = tf.shade(
                 tf.spread(cvs.points(dfact, "x", "y", ds.any()), px=px),
                 cmap=active_color,
@@ -601,72 +367,3 @@ class SnapWaveQuadtreeMask(ModelComponent):
         except Exception as e:
             print(e)
             return False
-
-
-def get_neighbors_in_larger_cell(n, m):
-    nnbr = [-1, -1, -1, -1]
-    mnbr = [-1, -1, -1, -1]
-    if not odd(n) and not odd(m):
-        # lower left
-        nnbr[0] = n + 1
-        mnbr[0] = m
-        nnbr[1] = n
-        mnbr[1] = m + 1
-        nnbr[2] = n + 1
-        mnbr[2] = m + 1
-    elif not odd(n) and odd(m):
-        # lower right
-        nnbr[1] = n
-        mnbr[1] = m - 1
-        nnbr[2] = n + 1
-        mnbr[2] = m - 1
-        nnbr[3] = n + 1
-        mnbr[3] = m
-    elif odd(n) and not odd(m):
-        # upper left
-        nnbr[1] = n - 1
-        mnbr[1] = m
-        nnbr[2] = n - 1
-        mnbr[2] = m + 1
-        nnbr[3] = n
-        mnbr[3] = m + 1
-    else:
-        # upper right
-        nnbr[1] = n - 1
-        mnbr[1] = m - 1
-        nnbr[2] = n - 1
-        mnbr[2] = m
-        nnbr[3] = n
-        mnbr[3] = m - 1
-    return nnbr, mnbr
-
-
-def odd(num):
-    if (num % 2) == 1:
-        return True
-    else:
-        return False
-
-
-def even(num):
-    if (num % 2) == 0:
-        return True
-    else:
-        return False
-
-
-def inpolygon(xq, yq, p):
-    shape = xq.shape
-    xq = xq.reshape(-1)
-    yq = yq.reshape(-1)
-    q = [(xq[i], yq[i]) for i in range(xq.shape[0])]
-    p = path.Path([(crds[0], crds[1]) for i, crds in enumerate(p.exterior.coords)])
-    return p.contains_points(q).reshape(shape)
-
-
-def binary_search(vals, val):
-    indx = np.searchsorted(vals, val)
-    if indx < np.size(vals):
-        if vals[indx] == val:
-            return indx
-    return None

--- a/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
@@ -1,30 +1,16 @@
 import logging
-import os
 from pathlib import Path
 import warnings
 from typing import TYPE_CHECKING, Union
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
-from pyproj import Transformer
 
 from hydromt import hydromt_step
 
 from hydromt_sfincs.components.quadtree import SfincsQuadtreeMask
 
 np.warnings = warnings
-
-# optional dependency
-try:
-    import datashader as ds
-    import datashader.transfer_functions as tf
-    from datashader.utils import export_image
-
-    HAS_DATASHADER = True
-
-except ImportError:
-    HAS_DATASHADER = False
 
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
@@ -34,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 
 class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
+    # Variable name used by the overlay renderer (parent reads "mask"; this
+    # subclass renders the snapwave mask instead).
+    _mask_variable: str = "snapwave_mask"
+
     def __init__(
         self,
         model: "SfincsModel",
@@ -41,9 +31,6 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
         super().__init__(
             model=model,
         )
-        # For plotting map overlay (This is the only data that is stored in the object!
-        # All other data is stored in the model.grid.data["mask"])
-        self.datashader_dataframe = pd.DataFrame()
 
     @property
     def has_open_boundaries(self):
@@ -72,7 +59,6 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
         neumann_boundary_zmin: float = None,
         neumann_boundary_zmax: float = None,
         all_touched: bool = False,
-        update_datashader_dataframe=False,
     ):
         """Setup active model snapwave mask and add boundaries. Note that boundary types can only be set when polygons are provided.
 
@@ -117,7 +103,6 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
             neumann_boundary_zmin=neumann_boundary_zmin,
             neumann_boundary_zmax=neumann_boundary_zmax,
             all_touched=all_touched,
-            update_datashader_dataframe=update_datashader_dataframe,
         )
 
     @hydromt_step
@@ -255,105 +240,6 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
             connectivity=connectivity,
         )
 
-    def get_datashader_dataframe(self, variable="snapwave_mask"):
-        """Sets the datashader dataframe for plotting"""
-        super().get_datashader_dataframe(variable=variable)
-
-    def clear_datashader_dataframe(self):
-        """Clears the datashader dataframe"""
-        self.datashader_dataframe = pd.DataFrame()
-
-    def map_overlay(
-        self,
-        file_name,
-        xlim=None,
-        ylim=None,
-        colors=None,
-        px=2,
-        width=800,
-        **kwargs,
-    ):
-        """Create a map overlay image of the SnapWave mask using datashader.
-
-        Parameters
-        ----------
-        file_name : str
-            Output image file name.
-        xlim, ylim : list, optional
-            Geographic (lon/lat) extent of the image.
-        colors : dict, optional
-            Mapping of integer mask values to colour strings, e.g.
-            ``{1: "yellow", 2: "red", 3: "green"}``.  By default
-            ``{1: "yellow", 2: "red", 3: "green"}``.
-        px : int, optional
-            Marker radius in pixels, by default 2.
-        width : int, optional
-            Output image width in pixels, by default 800.
-
-        Returns
-        -------
-        bool
-            True if the image was created successfully, False otherwise.
-        """
-        if colors is None:
-            colors = {1: "yellow", 2: "red", 3: "green"}
-
-        if not HAS_DATASHADER:
-            logger.warning("Datashader is not available. Please install datashader.")
-            return False
-
-        if len(self.model.quadtree_grid.data.data_vars) == 0:
-            return False
-
-        try:
-            if self.datashader_dataframe.empty:
-                self.get_datashader_dataframe()
-
-            if self.datashader_dataframe.empty:
-                return False
-
-            transformer = Transformer.from_crs(4326, 3857, always_xy=True)
-            xl0, yl0 = transformer.transform(xlim[0], ylim[0])
-            xl1, yl1 = transformer.transform(xlim[1], ylim[1])
-            if xl0 > xl1:
-                xl1 += 40075016.68557849
-            xlim = [xl0, xl1]
-            ylim = [yl0, yl1]
-            ratio = (ylim[1] - ylim[0]) / (xlim[1] - xlim[0])
-            height = int(width * ratio)
-
-            cvs = ds.Canvas(
-                x_range=xlim, y_range=ylim, plot_height=height, plot_width=width
-            )
-
-            images = []
-            for mask_val, color in colors.items():
-                df_sub = self.datashader_dataframe[
-                    self.datashader_dataframe["snapwave_mask"] == mask_val
-                ]
-                if len(df_sub) > 0:
-                    images.append(
-                        tf.shade(
-                            tf.spread(cvs.points(df_sub, "x", "y", ds.any()), px=px),
-                            cmap=color,
-                        )
-                    )
-
-            if not images:
-                return False
-
-            img = images[0]
-            for im in images[1:]:
-                img = tf.stack(img, im)
-
-            path = os.path.dirname(file_name)
-            if not path:
-                path = os.getcwd()
-            name = os.path.basename(file_name)
-            name = os.path.splitext(name)[0]
-            export_image(img, name, export_path=path)
-            return True
-
-        except Exception as e:
-            print(e)
-            return False
+    # map_overlay / clear_overlay are inherited from SfincsQuadtreeMask;
+    # they consult ``_mask_variable`` (overridden above) to pick the
+    # right mask field.

--- a/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
@@ -268,40 +268,36 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
         file_name,
         xlim=None,
         ylim=None,
-        active_color="yellow",
-        boundary_color="red",
-        neumann_color="green",
+        colors=None,
         px=2,
         width=800,
+        **kwargs,
     ):
-        """Creates a map overlay image of the mask
+        """Create a map overlay image of the SnapWave mask using datashader.
 
         Parameters
         ----------
         file_name : str
-            The file name of the image
-        xlim : list, optional
-            The x limits of the image
-        ylim : list, optional
-            The y limits of the image
-        active_color : str, optional
-            The color of the active cells
-        boundary_color : str, optional
-            The color of the boundary cells
-        neumann_color : str, optional
-            The color of the neumann cells
+            Output image file name.
+        xlim, ylim : list, optional
+            Geographic (lon/lat) extent of the image.
+        colors : dict, optional
+            Mapping of integer mask values to colour strings, e.g.
+            ``{1: "yellow", 2: "red", 3: "green"}``.  By default
+            ``{1: "yellow", 2: "red", 3: "green"}``.
         px : int, optional
-            The marker size in pixels
+            Marker radius in pixels, by default 2.
         width : int, optional
-            The width of the image in pixels
+            Output image width in pixels, by default 800.
 
         Returns
         -------
         bool
-            True if the image was created successfully, False otherwise
+            True if the image was created successfully, False otherwise.
         """
+        if colors is None:
+            colors = {1: "yellow", 2: "red", 3: "green"}
 
-        # check if datashader is available
         if not HAS_DATASHADER:
             logger.warning("Datashader is not available. Please install datashader.")
             return False
@@ -310,11 +306,9 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
             return False
 
         try:
-            # Check if datashader dataframe is empty (maybe it was not made yet, or it was cleared)
             if self.datashader_dataframe.empty:
                 self.get_datashader_dataframe()
 
-            # If it is still empty (because there are no active cells), return False
             if self.datashader_dataframe.empty:
                 return False
 
@@ -332,29 +326,25 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
                 x_range=xlim, y_range=ylim, plot_height=height, plot_width=width
             )
 
-            # Instead, we can create separate images for each mask and stack them
-            dfact = self.datashader_dataframe[
-                self.datashader_dataframe["snapwave_mask"] == 1
-            ]
-            dfbnd = self.datashader_dataframe[
-                self.datashader_dataframe["snapwave_mask"] == 2
-            ]
-            dfout = self.datashader_dataframe[
-                self.datashader_dataframe["snapwave_mask"] == 3
-            ]
-            img_a = tf.shade(
-                tf.spread(cvs.points(dfact, "x", "y", ds.any()), px=px),
-                cmap=active_color,
-            )
-            img_b = tf.shade(
-                tf.spread(cvs.points(dfbnd, "x", "y", ds.any()), px=px),
-                cmap=boundary_color,
-            )
-            img_o = tf.shade(
-                tf.spread(cvs.points(dfout, "x", "y", ds.any()), px=px),
-                cmap=neumann_color,
-            )
-            img = tf.stack(img_a, img_b, img_o)
+            images = []
+            for mask_val, color in colors.items():
+                df_sub = self.datashader_dataframe[
+                    self.datashader_dataframe["snapwave_mask"] == mask_val
+                ]
+                if len(df_sub) > 0:
+                    images.append(
+                        tf.shade(
+                            tf.spread(cvs.points(df_sub, "x", "y", ds.any()), px=px),
+                            cmap=color,
+                        )
+                    )
+
+            if not images:
+                return False
+
+            img = images[0]
+            for im in images[1:]:
+                img = tf.stack(img, im)
 
             path = os.path.dirname(file_name)
             if not path:

--- a/hydromt_sfincs/utils.py
+++ b/hydromt_sfincs/utils.py
@@ -235,7 +235,7 @@ def read_xy(fn: Union[str, Path], crs: Union[int, CRS] = None) -> gpd.GeoDataFra
 
 
 def read_xyn(fn: str, crs: int = None):
-    df = pd.read_csv(fn, index_col=False, header=None, sep="\s+").rename(
+    df = pd.read_csv(fn, index_col=False, header=None, sep=r"\s+").rename(
         columns={0: "x", 1: "y"}
     )
     if len(df.columns) > 2:
@@ -299,7 +299,7 @@ def read_timeseries(fn: Union[str, Path], tref: Union[str, datetime]) -> pd.Data
         Dataframe of timeseries with parsed time index.
     """
     tref = parse_datetime(tref)
-    df = pd.read_csv(fn, index_col=0, header=None, sep="\s+")
+    df = pd.read_csv(fn, index_col=0, header=None, sep=r"\s+")
     df.index = pd.to_datetime(df.index.values, unit="s", origin=tref)
     df.columns = df.columns.values.astype(int) - 1  # convert to zero-based index
     df.index.name = "time"
@@ -1526,7 +1526,7 @@ def _downscale_floodmap_da(
             # if rotated grid, use xugrid regridder
             else:
                 # need to convert dep to unstructured to enable xugrid regridder
-                uda_dep = xu.UgridDataArray.from_structured(dep, "xc", "yc")
+                uda_dep = xu.UgridDataArray.from_structured2d(dep, "xc", "yc")
                 regridder = xu.CentroidLocatorRegridder(source=zsmax, target=uda_dep)
                 result = regridder.regrid(zsmax)
                 # map back to structured
@@ -1776,9 +1776,9 @@ def make_regular_grid(
     # CRS/Ugrid handling
     if make_ugrid:
         if rotation != 0.0:
-            da = UgridDataArray.from_structured(da, "xc", "yc")
+            da = UgridDataArray.from_structured2d(da, "xc", "yc")
         else:
-            da = UgridDataArray.from_structured(da)
+            da = UgridDataArray.from_structured2d(da)
         if crs is not None:
             da.grid.set_crs(crs)
     else:

--- a/hydromt_sfincs/workflows/__init__.py
+++ b/hydromt_sfincs/workflows/__init__.py
@@ -1,10 +1,12 @@
 """HydroMT SFINCS workflows"""
 
 from .bathymetry import *
+from .cog import *
 from .curvenumber import *
 from .discharge import *
 from .flwdir import *
 from .landuse import *
+from .map_overlay import *
 from .merge import *
 from .storage_volume import *
 from .tiling import *

--- a/hydromt_sfincs/workflows/cog.py
+++ b/hydromt_sfincs/workflows/cog.py
@@ -1,0 +1,134 @@
+"""Cloud-Optimized GeoTIFF (COG) outputs for SFINCS quadtree grids."""
+
+import logging
+from pathlib import Path
+from typing import List, Optional, Union
+
+import numpy as np
+import rasterio
+from rasterio.enums import Resampling
+from rasterio.transform import from_origin
+
+__all__ = ["make_index_cog", "make_topobathy_cog"]
+
+logger = logging.getLogger(__name__)
+
+
+def make_topobathy_cog(
+    quadtree_grid,
+    filename: Union[str, Path],
+    bathymetry_sets: List[dict],
+    bathymetry_database: Optional[object] = None,
+    dx: float = 10.0,
+) -> None:
+    """Write a COG raster sampling the model topobathy.
+
+    The COG is written in the model CRS, so this currently only supports
+    projected coordinate systems.
+
+    Parameters
+    ----------
+    quadtree_grid : SfincsQuadtreeGrid
+        Grid component providing ``bounds`` and ``model.crs``.
+    filename : str or Path
+        Output COG file path.
+    bathymetry_sets : list of dict
+        Dataset list passed through to
+        ``bathymetry_database.get_bathymetry_on_points``.
+    bathymetry_database : object, optional
+        Backing bathymetry database providing
+        ``get_bathymetry_on_points``. Required for this function to
+        produce data.
+    dx : float, optional
+        Raster resolution in model CRS units, by default ``10.0``.
+    """
+    bounds = quadtree_grid.bounds
+
+    x0, y0, x1, y1 = bounds[0], bounds[1], bounds[2], bounds[3]
+
+    # Round out to nearest dx
+    x0 = x0 - (x0 % dx)
+    x1 = x1 + (dx - x1 % dx)
+    y0 = y0 - (y0 % dx)
+    y1 = y1 + (dx - y1 % dx)
+
+    xx = np.arange(x0, x1, dx) + 0.5 * dx
+    yy = np.arange(y1, y0, -dx) - 0.5 * dx
+    xx, yy = np.meshgrid(xx, yy)
+
+    zz = bathymetry_database.get_bathymetry_on_points(
+        xx, yy, dx, quadtree_grid.model.crs, bathymetry_sets
+    )
+
+    with rasterio.open(
+        filename,
+        "w",
+        driver="COG",
+        height=zz.shape[0],
+        width=zz.shape[1],
+        count=1,
+        dtype=zz.dtype,
+        crs=quadtree_grid.model.crs,
+        transform=from_origin(x0, y1, dx, dx),
+        nodata=-999.0,
+    ) as dst:
+        dst.write(zz, 1)
+
+
+def make_index_cog(
+    quadtree_grid,
+    filename: Union[str, Path],
+    filename_topobathy: Union[str, Path],
+) -> None:
+    """Write a COG raster mapping each pixel to a quadtree cell index.
+
+    The output raster matches the resolution and grid of
+    ``filename_topobathy`` (typically produced by
+    :py:func:`make_topobathy_cog`). Pixels that do not fall inside any
+    active cell are filled with the ``uint32`` sentinel ``2147483647``.
+
+    Parameters
+    ----------
+    quadtree_grid : SfincsQuadtreeGrid
+        Grid component providing ``get_indices_at_points`` and
+        ``model.crs``.
+    filename : str or Path
+        Output COG file path.
+    filename_topobathy : str or Path
+        Reference topobathy COG whose grid / CRS define the output.
+    """
+    with rasterio.open(filename_topobathy) as src:
+        bounds = src.bounds
+        dx = src.res[0]
+        transform = src.transform
+        width = src.width
+        height = src.height
+        quadtree_grid.model.crs = src.crs
+
+    x0, y0, x1, y1 = bounds.left, bounds.bottom, bounds.right, bounds.top
+
+    xx = np.arange(x0, x1, dx) + 0.5 * dx
+    yy = np.arange(y1, y0, -dx) - 0.5 * dx
+    xx, yy = np.meshgrid(xx, yy)
+
+    nodata = 2147483647
+    indices = quadtree_grid.get_indices_at_points(xx, yy)
+    indices[indices == -999] = nodata
+
+    ii = np.empty((height, width), dtype=np.uint32)
+    ii[:, :] = indices
+
+    with rasterio.open(
+        filename,
+        "w",
+        driver="COG",
+        height=height,
+        width=width,
+        count=1,
+        dtype=ii.dtype,
+        crs=quadtree_grid.model.crs,
+        transform=transform,
+        nodata=nodata,
+        overview_resampling=Resampling.nearest,
+    ) as dst:
+        dst.write(ii, 1)

--- a/hydromt_sfincs/workflows/map_overlay.py
+++ b/hydromt_sfincs/workflows/map_overlay.py
@@ -1,0 +1,508 @@
+"""Datashader-based map-overlay rendering for SFINCS quadtree grids."""
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+import numpy as np
+import pandas as pd
+from pyproj import CRS, Transformer
+
+__all__ = [
+    "ElevationOverlay",
+    "MaskOverlay",
+    "MeshOverlay",
+    "make_edge_dataframe",
+    "make_elevation_overlay",
+    "make_elevation_trimesh",
+    "make_map_overlay",
+    "make_mask_dataframe",
+    "make_mask_overlay",
+]
+
+logger = logging.getLogger(__name__)
+
+# optional dependency
+try:
+    import datashader.transfer_functions as tf
+    from datashader import Canvas
+    from datashader.utils import export_image
+
+    HAS_DATASHADER = True
+except ImportError:
+    HAS_DATASHADER = False
+
+
+def make_edge_dataframe(ugrid, source_crs: CRS) -> pd.DataFrame:
+    """Build a datashader-ready edge-coordinate DataFrame in webmercator.
+
+    Produces one row per mesh edge with its two endpoints reprojected
+    from ``source_crs`` to EPSG:3857. If the source CRS is geographic
+    and any longitude exceeds 180, negative webmercator x values are
+    shifted by one world width so the line doesn't wrap back across the
+    dateline.
+
+    Parameters
+    ----------
+    ugrid : xugrid.Ugrid2d
+        Source mesh exposing ``edge_node_coordinates``.
+    source_crs : pyproj.CRS
+        CRS of the mesh coordinates.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``x1, y1, x2, y2`` in EPSG:3857.
+    """
+    x1 = ugrid.edge_node_coordinates[:, 0, 0]
+    x2 = ugrid.edge_node_coordinates[:, 1, 0]
+    y1 = ugrid.edge_node_coordinates[:, 0, 1]
+    y2 = ugrid.edge_node_coordinates[:, 1, 1]
+
+    cross_dateline = False
+    if source_crs.is_geographic and (np.max(x1) > 180.0 or np.max(x2) > 180.0):
+        cross_dateline = True
+
+    transformer = Transformer.from_crs(source_crs, 3857, always_xy=True)
+    x1, y1 = transformer.transform(x1, y1)
+    x2, y2 = transformer.transform(x2, y2)
+    if cross_dateline:
+        x1[x1 < 0] += 40075016.68557849
+        x2[x2 < 0] += 40075016.68557849
+
+    return pd.DataFrame(dict(x1=x1, y1=y1, x2=x2, y2=y2))
+
+
+def make_map_overlay(
+    dataframe: pd.DataFrame,
+    file_name: Union[str, Path],
+    xlim: Optional[List[float]] = None,
+    ylim: Optional[List[float]] = None,
+    color: str = "black",
+    width: int = 800,
+) -> bool:
+    """Render a PNG map overlay of mesh edges using datashader.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Edge DataFrame as produced by :py:func:`make_edge_dataframe`
+        (columns ``x1, y1, x2, y2`` in EPSG:3857).
+    file_name : str or Path
+        Output image path. The extension is stripped; datashader appends
+        ``.png``.
+    xlim : list of float, optional
+        Longitude limits ``[xmin, xmax]`` in EPSG:4326.
+    ylim : list of float, optional
+        Latitude limits ``[ymin, ymax]`` in EPSG:4326.
+    color : str, optional
+        Line colour, by default ``"black"``.
+    width : int, optional
+        Output image width in pixels; height is derived from the aspect
+        ratio of ``xlim`` / ``ylim``. Defaults to ``800``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the overlay was written, ``False`` if datashader is
+        unavailable, the dataframe is empty, or rendering raised an
+        exception.
+    """
+    if not HAS_DATASHADER:
+        logger.warning("Datashader is not available. Please install datashader.")
+        return False
+
+    if dataframe is None or dataframe.empty:
+        return False
+
+    try:
+        transformer = Transformer.from_crs(4326, 3857, always_xy=True)
+        xl0, yl0 = transformer.transform(xlim[0], ylim[0])
+        xl1, yl1 = transformer.transform(xlim[1], ylim[1])
+        if xl0 > xl1:
+            xl1 += 40075016.68557849
+        xlim = [xl0, xl1]
+        ylim = [yl0, yl1]
+        ratio = (ylim[1] - ylim[0]) / (xlim[1] - xlim[0])
+        height = int(width * ratio)
+
+        cvs = Canvas(x_range=xlim, y_range=ylim, plot_height=height, plot_width=width)
+        agg = cvs.line(dataframe, x=["x1", "x2"], y=["y1", "y2"], axis=1)
+        img = tf.shade(agg, cmap=color)
+
+        path_dir = os.path.dirname(file_name) or os.getcwd()
+        name = os.path.splitext(os.path.basename(file_name))[0]
+        export_image(img, name, export_path=path_dir)
+        return True
+    except Exception:
+        return False
+
+
+def make_mask_dataframe(
+    x: np.ndarray,
+    y: np.ndarray,
+    mask: np.ndarray,
+    source_crs: CRS,
+) -> pd.DataFrame:
+    """Build a datashader-ready point DataFrame for mask rendering.
+
+    Drops cells with ``mask <= 0`` and reprojects remaining cell centres
+    from ``source_crs`` to EPSG:3857. Dateline wrapping is applied when
+    the source CRS is geographic.
+
+    Parameters
+    ----------
+    x, y : np.ndarray
+        Cell-centre coordinates in the model CRS.
+    mask : np.ndarray
+        Integer mask values per cell.
+    source_crs : pyproj.CRS
+        CRS of ``x`` / ``y``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``x, y, mask`` in EPSG:3857. Empty if no active cells.
+    """
+    iok = np.where(mask > 0)
+    x = x[iok]
+    y = y[iok]
+    mask = mask[iok]
+    if x.size == 0:
+        return pd.DataFrame()
+
+    cross_dateline = source_crs.is_geographic and np.max(x) > 180.0
+    transformer = Transformer.from_crs(source_crs, 3857, always_xy=True)
+    x, y = transformer.transform(x, y)
+    if cross_dateline:
+        x[x < 0] += 40075016.68557849
+
+    return pd.DataFrame(dict(x=x, y=y, mask=mask))
+
+
+def make_mask_overlay(
+    dataframe: pd.DataFrame,
+    file_name: Union[str, Path],
+    xlim: Optional[List[float]] = None,
+    ylim: Optional[List[float]] = None,
+    colors: Optional[dict] = None,
+    px: int = 2,
+    width: int = 800,
+) -> bool:
+    """Render a PNG mask-overlay image using datashader.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Point DataFrame as produced by :py:func:`make_mask_dataframe`
+        (columns ``x, y, mask`` in EPSG:3857).
+    file_name : str or Path
+        Output image path. Datashader appends ``.png``.
+    xlim, ylim : list of float, optional
+        Lon/lat extent in EPSG:4326.
+    colors : dict, optional
+        Mapping of mask value → colour, e.g.
+        ``{1: "yellow", 2: "red", 3: "green"}``.
+    px : int, optional
+        Marker radius in pixels, by default ``2``.
+    width : int, optional
+        Output image width in pixels, by default ``800``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the image was written, ``False`` otherwise.
+    """
+    if colors is None:
+        colors = {1: "yellow", 2: "red", 3: "green", 5: "purple", 6: "blue"}
+
+    if not HAS_DATASHADER:
+        logger.warning("Datashader is not available. Please install datashader.")
+        return False
+
+    if dataframe is None or dataframe.empty:
+        return False
+
+    try:
+        import datashader as ds
+
+        transformer = Transformer.from_crs(4326, 3857, always_xy=True)
+        xl0, yl0 = transformer.transform(xlim[0], ylim[0])
+        xl1, yl1 = transformer.transform(xlim[1], ylim[1])
+        if xl0 > xl1:
+            xl1 += 40075016.68557849
+        xlim = [xl0, xl1]
+        ylim = [yl0, yl1]
+        ratio = (ylim[1] - ylim[0]) / (xlim[1] - xlim[0])
+        height = int(width * ratio)
+
+        cvs = Canvas(x_range=xlim, y_range=ylim, plot_height=height, plot_width=width)
+
+        images = []
+        for mask_val, color in colors.items():
+            df_sub = dataframe[dataframe["mask"] == mask_val]
+            if len(df_sub) > 0:
+                images.append(
+                    tf.shade(
+                        tf.spread(cvs.points(df_sub, "x", "y", ds.any()), px=px),
+                        cmap=color,
+                    )
+                )
+
+        if not images:
+            return False
+
+        img = images[0]
+        for im in images[1:]:
+            img = tf.stack(img, im)
+
+        path_dir = os.path.dirname(file_name) or os.getcwd()
+        name = os.path.splitext(os.path.basename(file_name))[0]
+        export_image(img, name, export_path=path_dir)
+        return True
+    except Exception:
+        return False
+
+
+class MaskOverlay:
+    """Lazy, cached mask-overlay renderer.
+
+    Holds the datashader DataFrame internally and rebuilds it on demand.
+    Components that want to render a mask overlay just hold one instance
+    and call :py:meth:`render` / :py:meth:`invalidate` — no need to expose
+    a dataframe attribute or a build method.
+    """
+
+    def __init__(self) -> None:
+        self._df: pd.DataFrame = pd.DataFrame()
+
+    def invalidate(self) -> None:
+        """Drop the cached dataframe; it will be rebuilt on next render."""
+        self._df = pd.DataFrame()
+
+    def render(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        mask: np.ndarray,
+        source_crs: CRS,
+        file_name: Union[str, Path],
+        xlim: Optional[List[float]] = None,
+        ylim: Optional[List[float]] = None,
+        colors: Optional[dict] = None,
+        px: int = 2,
+        width: int = 800,
+    ) -> bool:
+        """Render the mask overlay, rebuilding the cache if needed.
+
+        Parameters mirror :py:func:`make_mask_dataframe` (for the cache
+        build) and :py:func:`make_mask_overlay` (for the render).
+        """
+        if self._df.empty:
+            self._df = make_mask_dataframe(x, y, mask, source_crs)
+        return make_mask_overlay(
+            self._df, file_name, xlim=xlim, ylim=ylim,
+            colors=colors, px=px, width=width,
+        )
+
+
+class MeshOverlay:
+    """Lazy, cached grid-edge overlay renderer.
+
+    Holds the datashader DataFrame internally and rebuilds it on demand.
+    Components that want to render a grid-edge overlay just hold one
+    instance and call :py:meth:`render` / :py:meth:`invalidate` — no need
+    to expose a dataframe attribute or a build method.
+    """
+
+    def __init__(self) -> None:
+        self._df: pd.DataFrame = pd.DataFrame()
+
+    def invalidate(self) -> None:
+        """Drop the cached dataframe; it will be rebuilt on next render."""
+        self._df = pd.DataFrame()
+
+    def render(
+        self,
+        ugrid,
+        source_crs: CRS,
+        file_name: Union[str, Path],
+        xlim: Optional[List[float]] = None,
+        ylim: Optional[List[float]] = None,
+        color: str = "black",
+        width: int = 800,
+    ) -> bool:
+        """Render the edge overlay, rebuilding the cache if needed.
+
+        Parameters mirror :py:func:`make_edge_dataframe` (for the cache
+        build) and :py:func:`make_map_overlay` (for the render).
+        """
+        if self._df.empty:
+            self._df = make_edge_dataframe(ugrid, source_crs)
+        return make_map_overlay(
+            self._df, file_name, xlim=xlim, ylim=ylim, color=color, width=width,
+        )
+
+
+def make_elevation_trimesh(
+    face_xy: np.ndarray,
+    z: np.ndarray,
+    level: np.ndarray,
+    dx0: float,
+    dy0: float,
+    rotation: float,
+    source_crs: CRS,
+) -> "tuple[pd.DataFrame, pd.DataFrame]":
+    """Build datashader trimesh DataFrames from quadtree cell elevations.
+
+    Each finite-z cell becomes 4 vertices + 2 triangles. Coordinates are
+    reprojected from ``source_crs`` to EPSG:3857 (with dateline wrap).
+
+    Returns
+    -------
+    (vertices, simplices) : two pd.DataFrame
+        ``vertices`` has columns ``x, y, z``; ``simplices`` has ``v0, v1, v2``.
+        Both empty if no finite z values are present.
+    """
+    valid = np.isfinite(z)
+    n_valid = int(np.sum(valid))
+    if n_valid == 0:
+        return pd.DataFrame(), pd.DataFrame()
+
+    cx = face_xy[valid, 0]
+    cy = face_xy[valid, 1]
+    cz = z[valid]
+    clevel = (level - 1)[valid]  # 0-based refinement level
+
+    hdx = (dx0 / 2.0**clevel) / 2.0
+    hdy = (dy0 / 2.0**clevel) / 2.0
+
+    dx_offsets = np.array([-1, 1, 1, -1], dtype=np.float64)
+    dy_offsets = np.array([-1, -1, 1, 1], dtype=np.float64)
+
+    cosrot = np.cos(np.radians(rotation))
+    sinrot = np.sin(np.radians(rotation))
+
+    local_x = hdx[:, None] * dx_offsets[None, :]
+    local_y = hdy[:, None] * dy_offsets[None, :]
+    vx = cx[:, None] + cosrot * local_x - sinrot * local_y
+    vy = cy[:, None] + sinrot * local_x + cosrot * local_y
+
+    vx_flat = vx.ravel()
+    vy_flat = vy.ravel()
+    vz_flat = np.repeat(cz, 4)
+
+    transformer = Transformer.from_crs(source_crs, 3857, always_xy=True)
+    vx_3857, vy_3857 = transformer.transform(vx_flat, vy_flat)
+    if source_crs.is_geographic and np.max(face_xy[:, 0]) > 180.0:
+        vx_3857[vx_3857 < 0] += 40075016.68557849
+
+    vertices = pd.DataFrame({"x": vx_3857, "y": vy_3857, "z": vz_flat})
+
+    cell_idx = np.arange(n_valid, dtype=np.int32)
+    v_base = cell_idx * 4
+    t0 = np.column_stack([v_base, v_base + 1, v_base + 2])
+    t1 = np.column_stack([v_base, v_base + 2, v_base + 3])
+    tris = np.vstack([t0, t1])
+    simplices = pd.DataFrame({"v0": tris[:, 0], "v1": tris[:, 1], "v2": tris[:, 2]})
+
+    return vertices, simplices
+
+
+def make_elevation_overlay(
+    vertices: pd.DataFrame,
+    simplices: pd.DataFrame,
+    file_name: Union[str, Path],
+    xlim: Optional[List[float]] = None,
+    ylim: Optional[List[float]] = None,
+    cmap="gist_earth",
+    cmin: Optional[float] = None,
+    cmax: Optional[float] = None,
+    width: int = 800,
+) -> bool:
+    """Render an elevation trimesh overlay using datashader.
+
+    Parameters mirror :py:func:`make_elevation_trimesh` (for the data)
+    and add lon/lat extent, colormap and value-range controls.
+    """
+    if not HAS_DATASHADER:
+        logger.warning("Datashader is not available. Please install datashader.")
+        return False
+    if vertices is None or vertices.empty:
+        return False
+
+    try:
+        import datashader as ds
+
+        transformer = Transformer.from_crs(4326, 3857, always_xy=True)
+        xl0, yl0 = transformer.transform(xlim[0], ylim[0])
+        xl1, yl1 = transformer.transform(xlim[1], ylim[1])
+        if xl0 > xl1:
+            xl1 += 40075016.68557849
+        x_range = (xl0, xl1)
+        y_range = (yl0, yl1)
+        ratio = (y_range[1] - y_range[0]) / (x_range[1] - x_range[0])
+        height = int(width * ratio)
+
+        cvs = Canvas(
+            x_range=x_range, y_range=y_range, plot_width=width, plot_height=height,
+        )
+        mesh = ds.utils.mesh(vertices, simplices)
+        agg = cvs.trimesh(
+            vertices, simplices, mesh=mesh, agg=ds.mean("z"), interp=False,
+        )
+
+        if isinstance(cmap, str):
+            from matplotlib import colormaps
+
+            cmap = colormaps[cmap]
+        span = (cmin, cmax) if (cmin is not None and cmax is not None) else None
+        img = tf.shade(agg, cmap=cmap, span=span, how="linear")
+
+        path_dir = os.path.dirname(file_name) or os.getcwd()
+        name = os.path.splitext(os.path.basename(file_name))[0]
+        export_image(img, name, export_path=path_dir)
+        return True
+    except Exception:
+        return False
+
+
+class ElevationOverlay:
+    """Lazy, cached elevation trimesh overlay renderer."""
+
+    def __init__(self) -> None:
+        self._vertices: pd.DataFrame = pd.DataFrame()
+        self._simplices: pd.DataFrame = pd.DataFrame()
+
+    def invalidate(self) -> None:
+        """Drop the cached trimesh; it will be rebuilt on next render."""
+        self._vertices = pd.DataFrame()
+        self._simplices = pd.DataFrame()
+
+    def render(
+        self,
+        face_xy: np.ndarray,
+        z: np.ndarray,
+        level: np.ndarray,
+        dx0: float,
+        dy0: float,
+        rotation: float,
+        source_crs: CRS,
+        file_name: Union[str, Path],
+        xlim: Optional[List[float]] = None,
+        ylim: Optional[List[float]] = None,
+        cmap="gist_earth",
+        cmin: Optional[float] = None,
+        cmax: Optional[float] = None,
+        width: int = 800,
+    ) -> bool:
+        """Render the elevation overlay, rebuilding the trimesh if needed."""
+        if self._vertices.empty:
+            self._vertices, self._simplices = make_elevation_trimesh(
+                face_xy, z, level, dx0, dy0, rotation, source_crs,
+            )
+        return make_elevation_overlay(
+            self._vertices, self._simplices, file_name,
+            xlim=xlim, ylim=ylim, cmap=cmap, cmin=cmin, cmax=cmax, width=width,
+        )

--- a/hydromt_sfincs/workflows/tiling.py
+++ b/hydromt_sfincs/workflows/tiling.py
@@ -16,9 +16,173 @@ from pyproj import Transformer
 
 from .merge import merge_multi_dataarrays
 
-__all__ = ["create_topobathy_tiles", "downscale_floodmap_webmercator"]
+__all__ = [
+    "create_topobathy_tiles",
+    "downscale_floodmap_webmercator",
+    "write_html",
+]
 
 logger = logging.getLogger(__name__)
+
+
+def write_html(
+    file_name: Union[str, Path],
+    title: str = "hydromt-sfincs tiles",
+    legend_title: str = "Legend",
+    max_native_zoom: int = 19,
+) -> None:
+    """Write a standalone Leaflet HTML viewer for a tiled map layer.
+
+    The generated page loads OpenStreetMap and Esri World Imagery base
+    layers and overlays tiles from the URL pattern ``{z}/{x}/{y}.png``
+    relative to the HTML file. Drop it alongside a ``{z}/{x}/{y}.png``
+    tile tree and open it in a browser to preview the tiles.
+
+    Parameters
+    ----------
+    file_name : str or Path
+        Output HTML file path.
+    title : str, optional
+        Page heading shown above the map, by default
+        ``"hydromt-sfincs tiles"``.
+    legend_title : str, optional
+        Text displayed inside the legend box, by default ``"Legend"``.
+    max_native_zoom : int, optional
+        Maximum native zoom level of the tile layer, by default ``19``.
+    """
+    with open(file_name, "w") as f:
+        f.write("<!DOCTYPE html>\r\n")
+        f.write("<head>\r\n")
+        f.write(
+            "  <meta http-equiv='content-type' content='text/html; charset=UTF-8' />\r\n"
+        )
+        f.write("  <script>\r\n")
+        f.write("    L_NO_TOUCH = false;\r\n")
+        f.write("    L_DISABLE_3D = false;\r\n")
+        f.write("  </script>\r\n")
+        f.write(
+            "  <style>html, body {width: 100%;height: 100%;margin: 0;padding: 0;}</style>\r\n"
+        )
+        f.write(
+            "  <script src='https://cdn.jsdelivr.net/npm/leaflet@1.6.0/dist/leaflet.js'></script>\r\n"
+        )
+        f.write(
+            "  <script src='https://code.jquery.com/jquery-1.12.4.min.js'></script>\r\n"
+        )
+        f.write(
+            "  <script src='https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js'></script>\r\n"
+        )
+        f.write(
+            "  <script src='https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js'></script>\r\n"
+        )
+        f.write(
+            "  <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/leaflet@1.6.0/dist/leaflet.css'/>\r\n"
+        )
+        f.write(
+            "  <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css'/>\r\n"
+        )
+        f.write(
+            "  <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css'/>\r\n"
+        )
+        f.write(
+            "  <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css'/>\r\n"
+        )
+        f.write(
+            "  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css'/>\r\n"
+        )
+        f.write(
+            "  <link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css'/>\r\n"
+        )
+        f.write(
+            "  <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' />\r\n"
+        )
+        f.write("\r\n")
+        f.write("  <style>\r\n")
+        f.write("      #map { width: 800px; height: 500px; }\r\n")
+        f.write(
+            "      .info { padding: 6px 8px; font: 17px/19px Arial, Helvetica, sans-serif; background: white; background: rgba(255,255,255,0.8); box-shadow: 0 0 15px rgba(0,0,0,0.2); border-radius: 5px; } .info h4 { margin: 0 0 5px; color: #777; }\r\n"
+        )
+        f.write(
+            "      .legend     { text-align: center; line-height: 18px; color: #555; } .legend i     { width: 20px; height: 15px; float: left; margin-right: 8px; opacity: 0.7; border-style: solid; border-width: 1px;}\r\n"
+        )
+        f.write("  </style>\r\n")
+        f.write("\r\n")
+        f.write("</head>\r\n")
+        f.write("<body>\r\n")
+        f.write(f"  <h3> {title}</h3>\r\n")
+        f.write("  <div id='map' style='width: 100%; height: 90%;'></div>\r\n")
+        f.write("</body>\r\n")
+        f.write("<script>\r\n")
+        f.write("\r\n")
+        f.write("// Base layers\r\n")
+        f.write(
+            "var tile_layer_osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',\r\n"
+        )
+        f.write(
+            "    {'attribution': 'Data by http://openstreetmap.org href=http://www.openstreetmap.org',\r\n"
+        )
+        f.write("     'detectRetina': false,\r\n")
+        f.write("     'maxZoom': 19,\r\n")
+        f.write("     'minZoom': 0,\r\n")
+        f.write("     'noWrap': false,\r\n")
+        f.write("     'opacity': 1,\r\n")
+        f.write("     'maxNativeZoom': 13,\r\n")
+        f.write("     'subdomains': 'abc',\r\n")
+        f.write("     'tms': false});\r\n")
+        f.write(
+            "var Esri_WorldImagery = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {\r\n"
+        )
+        f.write(
+            "	attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'\r\n"
+        )
+        f.write("});\r\n")
+        f.write("\r\n")
+        f.write("// Data layer\r\n")
+        f.write("var tile_layer = L.tileLayer(\r\n")
+        f.write("    '{z}/{x}/{y}.png',\r\n")
+        f.write("    {'attribution': 'hydromt-sfincs',\r\n")
+        f.write("     'detectRetina': false,\r\n")
+        f.write("     'opacity': 0.7,\r\n")
+        f.write(f"     'maxNativeZoom': {max_native_zoom},\r\n")
+        f.write("     'maxZoom': 19,\r\n")
+        f.write("     'minZoom': 0,\r\n")
+        f.write("     'noWrap': false,\r\n")
+        f.write("     'subdomains': 'abc',\r\n")
+        f.write("     'zIndex':10,\r\n")
+        f.write("     'tms': false}\r\n")
+        f.write(");\r\n")
+        f.write("\r\n")
+        f.write("var legend = L.control({position: 'bottomright'});\r\n")
+        f.write("legend.onAdd = function (map) {\r\n")
+        f.write("        var div = L.DomUtil.create('div', 'info legend')\r\n")
+        f.write(f"        div.innerHTML += '{legend_title}<br>'\r\n")
+        f.write("        return div;\r\n")
+        f.write("};\r\n")
+        f.write("\r\n")
+        f.write("// Map\r\n")
+        f.write("var map = L.map('map',{\r\n")
+        f.write("    center: [0, 0],\r\n")
+        f.write("    crs: L.CRS.EPSG3857,\r\n")
+        f.write("    zoom: 2,\r\n")
+        f.write("    zoomControl: true,\r\n")
+        f.write("    preferCanvas: false,\r\n")
+        f.write("    layers: [tile_layer_osm, tile_layer]\r\n")
+        f.write("    }\r\n")
+        f.write(");\r\n")
+        f.write("\r\n")
+        f.write("legend.addTo(map);\r\n")
+        f.write("\r\n")
+        f.write("// Layer control\r\n")
+        f.write("var baseMaps = {\r\n")
+        f.write("    'Open Street Map': tile_layer_osm,\r\n")
+        f.write("    'Satellite': Esri_WorldImagery\r\n")
+        f.write("};\r\n")
+        f.write("\r\n")
+        f.write("var overlayMaps = {};\r\n")
+        f.write("\r\n")
+        f.write("L.control.layers(baseMaps, overlayMaps).addTo(map);\r\n")
+        f.write("\r\n")
+        f.write("</script>\r\n")
 
 
 def downscale_floodmap_webmercator(
@@ -136,9 +300,10 @@ def create_topobathy_tiles(
     index_path: Union[str, Path] = None,
     zoom_range: Union[int, List[int]] = [0, 13],
     z_range: List[int] = [-20000.0, 20000.0],
-    fmt="bin",
-    logger=logger,
-):
+    fmt: str = "bin",
+    write_html_viewer: bool = True,
+    logger: logging.Logger = logger,
+) -> None:
     """Create webmercator topobathy tiles for a given region.
 
     Parameters
@@ -155,8 +320,11 @@ def create_topobathy_tiles(
         Range of zoom levels for which tiles are created, by default [0, 13]
     z_range : List[int], optional
         Range of valid elevations, by default [-20000.0, 20000.0]
-    format : str, optional
+    fmt : str, optional
         The desired output format of the topobathy tiles, by default "bin". Also "png" and "tif" are supported.
+    write_html_viewer : bool, optional
+        If True (default), also write an ``index.html`` Leaflet viewer
+        alongside the tiles so they can be previewed in a browser.
     """
     # TODO change the order of the zoom_levels
     # basing large scale zoom levels on the high-resolution ones prevents memory errors
@@ -257,6 +425,15 @@ def create_topobathy_tiles(
                 elevation2png(da_dep, file_name)
             elif fmt == "tif":
                 da_dep.raster.to_raster(file_name)
+
+    if write_html_viewer and fmt == "png":
+        os.makedirs(topobathy_path, exist_ok=True)
+        write_html(
+            os.path.join(topobathy_path, "index.html"),
+            title="Topobathy tiles",
+            legend_title="Topobathy",
+            max_native_zoom=zoom_range[1],
+        )
 
 
 def deg2num(lat_deg, lon_deg, zoom):

--- a/hydromt_sfincs/workflows/tiling.py
+++ b/hydromt_sfincs/workflows/tiling.py
@@ -3,9 +3,10 @@
 import logging
 import math
 import os
+from concurrent.futures import ThreadPoolExecutor
 from itertools import product
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 import geopandas as gpd
 import numpy as np
@@ -19,6 +20,7 @@ from .merge import merge_multi_dataarrays
 __all__ = [
     "create_topobathy_tiles",
     "downscale_floodmap_webmercator",
+    "make_index_tiles",
     "write_html",
 ]
 
@@ -293,15 +295,151 @@ def downscale_floodmap_webmercator(
                     elevation2png(hmax, floodmap_fn)
 
 
+def make_index_tiles(
+    quadtree_grid,
+    root: Union[str, Path],
+    region: Optional[gpd.GeoDataFrame] = None,
+    zoom_range: Union[int, List[int]] = [0, 13],
+    fmt: str = "png",
+    write_html_viewer: bool = True,
+    max_workers: Optional[int] = None,
+    logger: logging.Logger = logger,
+) -> None:
+    """Create webmercator index tiles for an SFINCS quadtree grid.
+
+    Index tiles map each pixel of a webmercator XYZ tile to the index of
+    the corresponding SFINCS quadtree cell (``-999`` where there is no
+    match). Tiles are written to ``<root>/indices/<zoom>/<x>/<y>.<ext>``.
+
+    Parameters
+    ----------
+    quadtree_grid : SfincsQuadtreeGrid
+        Grid component providing ``get_indices_at_points``, ``exterior``,
+        and ``model.crs``.
+    root : Union[str, Path]
+        Parent directory; tiles land in ``<root>/indices``.
+    region : gpd.GeoDataFrame, optional
+        Area for which tiles are generated. Defaults to
+        ``quadtree_grid.exterior``.
+    zoom_range : Union[int, List[int]], optional
+        Range of zoom levels, by default ``[0, 13]``. A single int is
+        treated as ``[0, zoom_range]``.
+    fmt : str, optional
+        Output format: ``"png"`` (default) or ``"bin"`` (raw int32).
+    write_html_viewer : bool, optional
+        If True (default) and ``fmt == "png"``, write a Leaflet
+        ``index.html`` alongside the tiles.
+    max_workers : int, optional
+        Number of worker threads used to render tiles concurrently.
+        Defaults to ``os.cpu_count()``. Pass ``1`` to disable parallelism.
+    """
+    if region is None:
+        region = quadtree_grid.exterior
+
+    index_path = os.path.join(root, "indices")
+    npix = 256
+    extension = "dat" if fmt == "bin" else fmt
+
+    if isinstance(zoom_range, int):
+        zoom_range = [0, zoom_range]
+
+    # Webmercator bounds of the region
+    minx, miny, maxx, maxy = region.total_bounds
+    transformer = Transformer.from_crs(region.crs.to_epsg(), 3857)
+    if region.crs.is_geographic:
+        minx, miny = map(
+            max, zip(transformer.transform(miny, minx), [-20037508.34] * 2)
+        )
+        maxx, maxy = map(min, zip(transformer.transform(maxy, maxx), [20037508.34] * 2))
+    else:
+        minx, miny = map(
+            max, zip(transformer.transform(minx, miny), [-20037508.34] * 2)
+        )
+        maxx, maxy = map(min, zip(transformer.transform(maxx, maxy), [20037508.34] * 2))
+
+    transformer_inv = Transformer.from_crs(3857, quadtree_grid.model.crs, always_xy=True)
+
+    # Eagerly touch the lazy ifirst cache to avoid a race in worker threads.
+    _ = quadtree_grid.get_indices_at_points(np.array([[0.0]]), np.array([[0.0]]))
+
+    def _process_tile(izoom: int, transform: Affine, col: int, row: int) -> None:
+        zoom_path = os.path.join(index_path, str(izoom))
+        file_name = os.path.join(zoom_path, str(col), f"{row}.{extension}")
+
+        x = np.arange(0, npix) + 0.5
+        y = np.arange(0, npix) + 0.5
+        x3857, y3857 = transform * (x, y)
+        x3857, y3857 = np.meshgrid(x3857, y3857)
+
+        x_model, y_model = transformer_inv.transform(x3857, y3857)
+        ind = quadtree_grid.get_indices_at_points(x_model, y_model)
+
+        if np.any(ind >= 0):
+            os.makedirs(os.path.join(zoom_path, str(col)), exist_ok=True)
+            if fmt == "bin":
+                with open(file_name, "wb") as fid:
+                    fid.write(ind.astype(np.int32))
+            elif fmt == "png":
+                ind = ind.copy()
+                ind[ind == -999] = 0
+                int2png(ind, file_name)
+
+    max_workers = max_workers or os.cpu_count() or 1
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for izoom in range(zoom_range[0], zoom_range[1] + 1):
+            logger.debug(f"Processing zoom level {izoom}")
+            for transform, col, row in tile_window(izoom, minx, miny, maxx, maxy):
+                futures.append(
+                    executor.submit(_process_tile, izoom, transform, col, row)
+                )
+        for future in futures:
+            future.result()
+
+    if write_html_viewer and fmt == "png":
+        os.makedirs(index_path, exist_ok=True)
+        write_html(
+            os.path.join(index_path, "index.html"),
+            title="Index tiles",
+            legend_title="Cell indices",
+            max_native_zoom=zoom_range[1],
+        )
+
+
+def _resolve_elevation_list_from_catalog(
+    data_catalog, res: Optional[float] = None, bbox=None
+) -> List[dict]:
+    """Build an elevation_list by resolving every source in a data catalog.
+
+    Used as a fallback when no explicit ``elevation_list`` is supplied to
+    the tiling workflows. Assumes all sources in ``data_catalog`` are
+    raster elevation datasets (true in DelftDashboard, where the model's
+    catalog is populated only with topobathy sources).
+    """
+    resolved: List[dict] = []
+    for name in list(data_catalog.sources):
+        try:
+            zoom = (res, "meter") if res is not None else None
+            da = data_catalog.get_rasterdataset(name, bbox=bbox, buffer=10, zoom=zoom)
+            da.name = "elevation"
+        except Exception:
+            logger.warning(f"No data in domain for {name}, skipped.")
+            continue
+        resolved.append({"da": da})
+    return resolved
+
+
 def create_topobathy_tiles(
     root: Union[str, Path],
     region: gpd.GeoDataFrame,
-    elevation_list: List[dict],
+    elevation_list: Optional[List[dict]] = None,
+    data_catalog=None,
     index_path: Union[str, Path] = None,
     zoom_range: Union[int, List[int]] = [0, 13],
     z_range: List[int] = [-20000.0, 20000.0],
     fmt: str = "bin",
     write_html_viewer: bool = True,
+    max_workers: Optional[int] = None,
     logger: logging.Logger = logger,
 ) -> None:
     """Create webmercator topobathy tiles for a given region.
@@ -312,8 +450,14 @@ def create_topobathy_tiles(
         Directory where the topobathy tiles will be stored.
     region : gpd.GeoDataFrame
         GeoDataFrame defining the region for which the tiles will be created.
-    elevation_list : List[dict]
-        List of dictionaries containing the bathymetry dataarrays.
+    elevation_list : List[dict], optional
+        List of dictionaries containing the bathymetry dataarrays. If
+        ``None``, falls back to ``data_catalog`` (all sources in the
+        catalog are treated as elevation datasets).
+    data_catalog : hydromt.DataCatalog, optional
+        Fallback data catalog used to build an elevation_list when
+        ``elevation_list`` is ``None``. Explicit ``elevation_list``
+        entries always win.
     index_path : Union[str, Path], optional
         Directory where index tiles are stored, by default None
     zoom_range : Union[int, List[int]], optional
@@ -329,10 +473,23 @@ def create_topobathy_tiles(
     # TODO change the order of the zoom_levels
     # basing large scale zoom levels on the high-resolution ones prevents memory errors
 
-    assert len(elevation_list) > 0, "No DEMs provided"
-
     topobathy_path = os.path.join(root, "topobathy")
     npix = 256
+
+    # if only one zoom level is specified, create tiles up to that zoom level
+    if isinstance(zoom_range, int):
+        zoom_range = [0, zoom_range]
+
+    # Fall back to the data catalog when no explicit elevation_list was
+    # supplied. An explicit elevation_list always wins over the catalog.
+    if (elevation_list is None or len(elevation_list) == 0) and data_catalog is not None:
+        res = 40075016.686 / 256 / 2 ** zoom_range[1]
+        bbox = tuple(region.to_crs(4326).total_bounds)
+        elevation_list = _resolve_elevation_list_from_catalog(
+            data_catalog, res=res, bbox=bbox
+        )
+
+    assert elevation_list is not None and len(elevation_list) > 0, "No DEMs provided"
 
     # for binary format, use .dat extension
     if fmt == "bin":
@@ -340,10 +497,6 @@ def create_topobathy_tiles(
     # for net, tif and png extension and format are the same
     else:
         extension = fmt
-
-    # if only one zoom level is specified, create tiles up to that zoom level (inclusive)
-    if isinstance(zoom_range, int):
-        zoom_range = [0, zoom_range]
 
     # get bounding box of region
     minx, miny, maxx, maxy = region.total_bounds
@@ -361,70 +514,68 @@ def create_topobathy_tiles(
         )
         maxx, maxy = map(min, zip(transformer.transform(maxx, maxy), [20037508.34] * 2))
 
-    for izoom in range(zoom_range[0], zoom_range[1] + 1):
-        logger.debug("Processing zoom level " + str(izoom))
-
+    def _process_tile(izoom: int, transform: Affine, col: int, row: int) -> None:
         zoom_path = os.path.join(topobathy_path, str(izoom))
+        file_name = os.path.join(zoom_path, str(col), f"{row}.{extension}")
 
-        for transform, col, row in tile_window(izoom, minx, miny, maxx, maxy):
-            # transform is a rasterio Affine object
-            # col, row are the tile indices
-            file_name = os.path.join(zoom_path, str(col), str(row) + "." + extension)
+        if index_path:
+            # Only make tiles for which there is an index file (.dat or .png)
+            idx_dat = os.path.join(index_path, str(izoom), str(col), f"{row}.dat")
+            idx_png = os.path.join(index_path, str(izoom), str(col), f"{row}.png")
+            if not os.path.exists(idx_dat) and not os.path.exists(idx_png):
+                return
 
-            if index_path:
-                # Only make tiles for which there is an index file (can be .dat or .png)
-                index_file_name_dat = os.path.join(
-                    index_path, str(izoom), str(col), str(row) + ".dat"
-                )
-                index_file_name_png = os.path.join(
-                    index_path, str(izoom), str(col), str(row) + ".png"
-                )
-                if not os.path.exists(index_file_name_dat) and not os.path.exists(
-                    index_file_name_png
-                ):
-                    continue
+        x = np.arange(0, npix) + 0.5
+        y = np.arange(0, npix) + 0.5
+        x3857, y3857 = transform * (x, y)
+        zg = np.float32(np.full([npix, npix], np.nan))
 
-            x = np.arange(0, npix) + 0.5
-            y = np.arange(0, npix) + 0.5
-            x3857, y3857 = transform * (x, y)
-            zg = np.float32(np.full([npix, npix], np.nan))
+        da_dep = xr.DataArray(
+            zg,
+            coords={"y": y3857, "x": x3857},
+            dims=["y", "x"],
+        )
+        da_dep.raster.set_crs(3857)
+        # Tell rioxarray which dims are spatial so it can derive the
+        # transform from the coordinate arrays (avoids
+        # NotGeoreferencedWarning during reprojection).
+        da_dep.rio.set_spatial_dims(x_dim="x", y_dim="y", inplace=True)
 
-            da_dep = xr.DataArray(
-                zg,
-                coords={"y": y3857, "x": x3857},
-                dims=["y", "x"],
-            )
-            da_dep.raster.set_crs(3857)
+        da_dep = merge_multi_dataarrays(
+            da_list=elevation_list,
+            da_like=da_dep,
+        )
 
-            # get subgrid bathymetry tile
-            da_dep = merge_multi_dataarrays(
-                da_list=elevation_list,
-                da_like=da_dep,
-            )
+        if np.isnan(da_dep.values).all():
+            return
 
-            if np.isnan(da_dep.values).all():
-                # only nans in this tile
-                continue
+        if (
+            np.nanmax(da_dep.values) < z_range[0]
+            or np.nanmin(da_dep.values) > z_range[1]
+        ):
+            return
 
-            if (
-                np.nanmax(da_dep.values) < z_range[0]
-                or np.nanmin(da_dep.values) > z_range[1]
-            ):
-                # all values in tile outside z_range
-                continue
+        os.makedirs(os.path.join(zoom_path, str(col)), exist_ok=True)
 
-            if not os.path.exists(os.path.join(zoom_path, str(col))):
-                os.makedirs(os.path.join(zoom_path, str(col)))
-
-            if fmt == "bin":
-                # And write indices to file
-                fid = open(file_name, "wb")
+        if fmt == "bin":
+            with open(file_name, "wb") as fid:
                 fid.write(da_dep.values)
-                fid.close()
-            elif fmt == "png":
-                elevation2png(da_dep, file_name)
-            elif fmt == "tif":
-                da_dep.raster.to_raster(file_name)
+        elif fmt == "png":
+            elevation2png(da_dep, file_name)
+        elif fmt == "tif":
+            da_dep.raster.to_raster(file_name)
+
+    max_workers = max_workers or os.cpu_count() or 1
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for izoom in range(zoom_range[0], zoom_range[1] + 1):
+            logger.debug(f"Processing zoom level {izoom}")
+            for transform, col, row in tile_window(izoom, minx, miny, maxx, maxy):
+                futures.append(
+                    executor.submit(_process_tile, izoom, transform, col, row)
+                )
+        for future in futures:
+            future.result()
 
     if write_html_viewer and fmt == "png":
         os.makedirs(topobathy_path, exist_ok=True)

--- a/tests/test_quadtree.py
+++ b/tests/test_quadtree.py
@@ -56,6 +56,45 @@ def test_quadtree_io(tmp_dir):
     os.remove(mod1.root.path / "sfincs.nc")
 
 
+def test_quadtree_create_index_tiles(quadtree_model, tmp_dir):
+    # Zoom range has to be high enough that tile pixels resolve the
+    # ~13 x 10 km test model; keep it tight so the test stays fast.
+    zoom_range = [12, 13]
+
+    # PNG (default format)
+    root_png = tmp_dir / "tiles_png"
+    quadtree_model.quadtree_grid.create_index_tiles(
+        root=root_png, zoom_range=zoom_range
+    )
+    png_files = list((root_png / "indices").rglob("*.png"))
+    assert len(png_files) > 0
+    # Tiles are nested as <indices>/<zoom>/<x>/<y>.png
+    zoom_levels = {int(p.parts[-3]) for p in png_files}
+    assert zoom_levels.issubset(set(range(zoom_range[0], zoom_range[1] + 1)))
+    assert max(zoom_levels) == zoom_range[1]
+    # HTML viewer is written by default alongside PNG tiles
+    html_file = root_png / "indices" / "index.html"
+    assert html_file.is_file()
+    assert "{z}/{x}/{y}.png" in html_file.read_text()
+
+    # Binary format
+    root_bin = tmp_dir / "tiles_bin"
+    quadtree_model.quadtree_grid.create_index_tiles(
+        root=root_bin, zoom_range=zoom_range, fmt="bin"
+    )
+    dat_files = list((root_bin / "indices").rglob("*.dat"))
+    assert len(dat_files) > 0
+    # Each .dat tile should be 256*256 int32 = 262144 bytes
+    assert dat_files[0].stat().st_size == 256 * 256 * 4
+    # Indices in the .dat tile must be valid cell indices (or -999 nodata)
+    data = np.fromfile(dat_files[0], dtype=np.int32).reshape(256, 256)
+    nr_cells = len(quadtree_model.quadtree_grid.data["level"])
+    valid = data[data != -999]
+    assert valid.size > 0
+    assert valid.min() >= 0
+    assert valid.max() < nr_cells
+
+
 def test_xu_open_dataset_delete(tmp_dir):
     # copy the test data to the tmp_path
     fn = join(TESTDATADIR, "sfincs_test_quadtree", "sfincs.nc")


### PR DESCRIPTION
> ⚠️  **Stacked PR** — base branch is `feat/sfincs-ddb-adaptations` (#369). Please merge that one first, or retarget to `main` afterwards (GitHub will auto-retarget when #369 merges).

## Summary
Centralises datashader rendering and tile/COG generation into the `workflows/` package; components become thin wrappers over reusable classes/functions. **No behaviour change intended** — same PNGs / COGs, same file formats.

**New workflow modules**
- `workflows/cog.py` — `make_topobathy_cog`, `make_index_cog`.
- `workflows/map_overlay.py` — `MeshOverlay`, `MaskOverlay`, `ElevationOverlay` classes (lazy caches with `render()` / `invalidate()`), plus helper functions (`make_edge_dataframe`, `make_map_overlay`, `make_mask_dataframe`, `make_mask_overlay`, `make_elevation_trimesh`, `make_elevation_overlay`).

**Tiling**
- `workflows/tiling.py` gets parallelised tile loops via `ThreadPoolExecutor(max_workers)`, a dedicated `make_index_tiles`, optional `data_catalog=` fallback when `elevation_list is None`, a Leaflet `write_html` viewer, and a `write_html_viewer=True` flag on grid `create_index_tiles` / `create_topobathy_tiles`.

**Component simplifications**
- `SfincsQuadtreeGrid` / `SfincsQuadtreeElevation` / `SfincsQuadtreeMask` / `SnapWaveQuadtreeMask`: replaced inline datashader state with overlay instances + thin wrappers; added `clear_overlay()`.
- `SnapWaveQuadtreeMask` is now a subclass with `_mask_variable = "snapwave_mask"` inheriting the parent's renderer.
- `grid/mask.py` and `grid/regulargrid.py`: removed dead datashader stubs.

**Bundled with the refactor**
- `water_level.set_boundary_conditions_astro(gdf)` to accept per-point astronomical constants from a GDF; cleaner `.bca` output.
- `@hydromt_step` on `quadtree_grid.cut_inactive_cells` so it's YAML-addressable.
- Guard in `quadtree_mask.map_overlay` for a mask variable that isn't built yet.
- `utils.py`: `sep=r"\s+"` raw-string (SyntaxWarning) and `xu.UgridDataArray.from_structured → from_structured2d` (deprecation).
- `tests/test_quadtree.py`: `test_quadtree_create_index_tiles` exercises PNG + binary tile output and the HTML viewer.

## Test plan
- [ ] Full hydromt_sfincs test suite passes
- [ ] Visual check: render a grid overlay, a mask overlay, a snapwave mask overlay, an elevation overlay — all match the previous outputs
- [ ] Generate index tiles (PNG + binary) and topobathy tiles; verify the HTML viewer renders in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)