### PR TITLE
Simplify linestring2gdf, drop elevation handling

### DIFF
--- a/hydromt_sfincs/components/geometries/weirs.py
+++ b/hydromt_sfincs/components/geometries/weirs.py
@@ -7,6 +7,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
+from shapely.geometry import LineString
 
 from hydromt import hydromt_step
 from hydromt.model.components import ModelComponent
@@ -260,6 +261,22 @@ class SfincsWeirs(ModelComponent):
         if not gdf.geometry.type.isin(["LineString"]).all():
             raise ValueError("Weirs must be of type LineString.")
 
+        # Weir geometries are stored as 2D LineStrings; any per-vertex Z
+        # values coming from the input (e.g. 3D LineStrings in a geojson)
+        # are moved into the ``elevation`` column instead.
+        if gdf.geometry.apply(lambda geom: geom.has_z).any():
+            has_z_mask = gdf.geometry.apply(lambda geom: geom.has_z)
+            if "elevation" not in gdf.columns:
+                gdf["elevation"] = None
+            for irow in gdf.index[has_z_mask]:
+                coords = list(gdf.at[irow, "geometry"].coords)
+                gdf.at[irow, "elevation"] = [c[2] for c in coords]
+            gdf.geometry = gdf.geometry.apply(
+                lambda geom: LineString([(x, y) for x, y, *_ in geom.coords])
+                if geom.has_z
+                else geom
+            )
+
         # expected columns in gdf
         cols = {
             "weir": ["name", "elevation", "par1", "geometry"],
@@ -269,10 +286,7 @@ class SfincsWeirs(ModelComponent):
         gdf = gdf[[c for c in cols["weir"] if c in gdf.columns]]
 
         # check whether elevation values are part of the gdf, or need to be calculated
-        gdf_has_elevation = (
-            gdf.geometry.apply(lambda geom: geom.has_z).all()
-            or "elevation" in gdf.columns
-        )
+        gdf_has_elevation = "elevation" in gdf.columns
 
         # check if elevation values are provided or can be calculated
         if not gdf_has_elevation and (dep is None and dz is None):

--- a/hydromt_sfincs/utils.py
+++ b/hydromt_sfincs/utils.py
@@ -659,10 +659,8 @@ def linestring2gdf(feats: List[Dict], crs: Union[int, CRS] = None) -> gpd.GeoDat
     records = []
     for f in feats:
         feat = copy.deepcopy(f)
-        xyz = [feat.pop("x"), feat.pop("y")]
-        if "elevation" in feat and np.atleast_1d(feat["elevation"]).size == len(xyz[0]):
-            xyz.append(feat.pop("elevation"))
-        feat.update({"geometry": LineString(list(zip(*xyz)))})
+        xy = [feat.pop("x"), feat.pop("y")]
+        feat.update({"geometry": LineString(list(zip(*xy)))})
         records.append(feat)
     gdf = gpd.GeoDataFrame.from_records(records)
     gdf.set_geometry("geometry", inplace=True)

--- a/tests/test_weirs.py
+++ b/tests/test_weirs.py
@@ -153,8 +153,8 @@ def test_determine_weir_elevation(model_config):
     # check if data is added
     obs0 = model_config.weirs.data
 
-    # Extract the z values
-    z_values = obs0.geometry.apply(lambda point: point.coords[0][2])
+    # Elevation is stored per-vertex in the 'elevation' column (geometry is 2D).
+    z_values = obs0["elevation"].apply(lambda v: v[0])
 
     # check first elevation value
     assert np.isclose(z_values[0], 0.021235, atol=1e-05)
@@ -164,7 +164,7 @@ def test_determine_weir_elevation(model_config):
 
     # check first elevation value
     obs1 = model_config.weirs.data
-    z_values1 = obs1.geometry.apply(lambda point: point.coords[0][2])
+    z_values1 = obs1["elevation"].apply(lambda v: v[0])
 
     assert np.isclose(
         z_values1[0], 2.021235, atol=1e-05


### PR DESCRIPTION
I believe the elevation option is only used in weirs. I strongly prefer that elevation is stored as a separate column, and not in the geometry. This makes handling the weirs in Delft Dashboard much more straightforward.

Construct 2D LineString from x and y only in linestring2gdf. Replaced the xyz variable and removed the conditional that appended an elevation coordinate, so geometries are now created from (x, y) pairs only. Callers that previously relied on elevation/z coordinates in the geometry will no longer receive 3D LineStrings.

## Issue addressed
Fixes #<issue number>

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
