### PR TITLE
Feat: separate function for reading config

### DIFF
--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -239,6 +239,7 @@ Input/Output methods
 .. autosummary::
    :toctree: ../_generated/
 
+   readers.read_config
    utils.read_binary_map
    utils.write_binary_map
    utils.read_binary_map_index

--- a/hydromt_sfincs/components/config/config.py
+++ b/hydromt_sfincs/components/config/config.py
@@ -1,7 +1,5 @@
 import logging
-from ast import literal_eval
-from datetime import datetime
-from os.path import abspath, exists, isabs, join
+from os.path import abspath, isabs, join
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 

--- a/hydromt_sfincs/components/config/config.py
+++ b/hydromt_sfincs/components/config/config.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from hydromt import hydromt_step
 from hydromt.model.components import ModelComponent
 
-from .config_variables import SfincsConfigVariables
+from hydromt_sfincs.readers import read_config
+from hydromt_sfincs.components.config.config_variables import SfincsConfigVariables
 
 if TYPE_CHECKING:
     from hydromt_sfincs import SfincsModel
@@ -64,50 +65,8 @@ class SfincsConfig(ModelComponent):
 
         self.root._assert_read_mode
 
-        if not exists(self.filename):
-            raise FileNotFoundError(
-                f"SFINCS input file '{self.filename}' does not exist."
-            )
-
-        # Read the file line by line
-        with open(self.filename, "r") as fid:
-            lines = fid.readlines()
-
-        inp_dict = {}
-        for line in lines:
-            # Check if first character is #
-            if line.strip().startswith("#"):
-                # Full line comment
-                continue
-            # Find last character before #
-            comment_idx = line.find("#")
-            if comment_idx >= 0:
-                line = line[:comment_idx]
-            line = [x.strip() for x in line.split("=")]
-            if len(line) != 2:
-                continue
-            name, val = line
-            if name in ["tref", "tstart", "tstop"]:
-                try:
-                    val = datetime.strptime(val, "%Y%m%d %H%M%S")
-                except ValueError:
-                    ValueError(f'"{name} = {val}" not understood.')
-            elif name in ["cdwnd", "cdval"]:
-                val = [float(x) for x in val.split()]
-            elif name == "utmzone":
-                val = str(val)
-            else:
-                try:
-                    val = literal_eval(val)
-                except Exception:
-                    pass
-
-            if name == "crs":
-                name = "epsg"
-            elif name == "dtout":
-                name = "dtmapout"
-
-            inp_dict[name] = val
+        # Read the config file
+        inp_dict = read_config(filename=self.filename)
 
         # FIXME: when reading an existing config, you don't want to start with all possible variables?
         # Convert dictionary to SfincsConfig instance

--- a/hydromt_sfincs/readers.py
+++ b/hydromt_sfincs/readers.py
@@ -1,0 +1,75 @@
+"""Standalone reader functions for HydroMT-SFINCS."""
+
+from ast import literal_eval
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+__all__ = ["read_config"]
+
+
+def read_config(
+    filename: Path | str,
+) -> dict[str, Any]:
+    """Read the SFINCS input file (sfincs.inp).
+
+    Parameters
+    ----------
+    filename : Path | str
+        The path to the input file containing the SFINCS model settings.
+
+    Returns
+    -------
+    dict[str, Any]
+        The model settings.
+    """
+    # Ensure typing
+    filename = Path(filename)
+    # Check if exists
+    if not filename.exists():
+        raise FileNotFoundError(
+            f"SFINCS input file '{filename.as_posix()}' does not exist."
+        )
+
+    # Read the file line by line
+    with open(filename, "r") as fid:
+        lines = fid.readlines()
+
+    inp_dict = {}
+    for line in lines:
+        # Check if first character is #
+        if line.strip().startswith("#"):
+            # Full line comment
+            continue
+        # Find last character before #
+        comment_idx = line.find("#")
+        if comment_idx >= 0:
+            line = line[:comment_idx]
+        line = [x.strip() for x in line.split("=")]
+        if len(line) != 2:
+            continue
+        name, val = line
+        if name in ["tref", "tstart", "tstop"]:
+            try:
+                val = datetime.strptime(val, "%Y%m%d %H%M%S")
+            except ValueError:
+                ValueError(f'"{name} = {val}" not understood.')
+        elif name in ["cdwnd", "cdval"]:
+            val = [float(x) for x in val.split()]
+        elif name == "utmzone":
+            val = str(val)
+        else:
+            try:
+                val = literal_eval(val)
+            except Exception:
+                pass
+
+        if name == "crs":
+            name = "epsg"
+        elif name == "dtout":
+            name = "dtmapout"
+
+        inp_dict[name] = val
+
+        # Return the config values
+        return inp_dict

--- a/hydromt_sfincs/readers.py
+++ b/hydromt_sfincs/readers.py
@@ -53,7 +53,7 @@ def read_config(
             try:
                 val = datetime.strptime(val, "%Y%m%d %H%M%S")
             except ValueError:
-                ValueError(f'"{name} = {val}" not understood.')
+                raise ValueError(f'"{name} = {val}" not understood.')
         elif name in ["cdwnd", "cdval"]:
             val = [float(x) for x in val.split()]
         elif name == "utmzone":

--- a/hydromt_sfincs/readers.py
+++ b/hydromt_sfincs/readers.py
@@ -71,5 +71,5 @@ def read_config(
 
         inp_dict[name] = val
 
-        # Return the config values
-        return inp_dict
+    # Return the config values
+    return inp_dict

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,6 @@ tests = "pytest -v --cov=hydromt_sfincs -cov-report=term-missing"
 
 [dependencies]
 python = "3.13.*"
-pytest = ">=9.1.0,<10"
 
 [pypi-dependencies]
 hydromt_sfincs = { path = ".", editable = true, extras = ["full"] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,6 +31,7 @@ tests = "pytest -v --cov=hydromt_sfincs -cov-report=term-missing"
 
 [dependencies]
 python = "3.13.*"
+pytest = ">=9.1.0,<10"
 
 [pypi-dependencies]
 hydromt_sfincs = { path = ".", editable = true, extras = ["full"] }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,13 @@ def tmp_dir(tmp_path_factory):
     return tmp_path_factory.mktemp("data")
 
 
+@pytest.fixture(scope="session")
+def config_path() -> Path:
+    p = Path(TESTMODELDIR, "sfincs.inp")
+    assert p.is_file()
+    return p
+
+
 @pytest.fixture
 def data_catalog():
     return DataCatalog("artifact_data")

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from hydromt_sfincs.readers import read_config
+
+
+def test_read_config(config_path: Path):
+    # Call the function:
+    inp = read_config(filename=config_path)
+
+    # Assert the output\
+    assert inp["mmax"] == 84
+    assert inp["nmax"] == 36
+    assert "depfile" in inp
+    assert "inifile" not in inp
+    assert int(inp["zsini"]) == 0
+
+
+def test_read_config_errors(tmp_path: Path, config_path: Path):
+    p = Path(tmp_path, "sfincs.inp")
+    # With a nonsense path
+    with pytest.raises(
+        FileNotFoundError,
+        match=f"SFINCS input file '{p.as_posix()}' does not exist.",
+    ):
+        _ = read_config(filename=p)
+
+    # Read and alter the data
+    with open(config_path, "r") as reader:
+        data = reader.read()
+    data = data.replace("20100201 000000", "foo")
+    with open(p, "w") as writer:
+        writer.write(data)
+    # Read with a nonsense time value
+    with pytest.raises(ValueError, match='"tref = foo" not understood.'):
+        _ = read_config(filename=p)


### PR DESCRIPTION
## Issue addressed
Fixes nothing in particular

## Explanation
Separated the reading/ parsing part of the `read` method of the config component into a separate function in the readers submodule. I think it can be nice to be able to read the config file outside of the context of the component/ model. This doesn't need to be in `readers.py` but that was just my first guess. Feel free to close it, if you fully disagree with this PR.
EDIT: Shall I just put in in `utils` or might something like the `readers` and `writers` modules such as in core be an idea.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [ ] Updated changelog.rst if needed 

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
