### PR TITLE
Update notebook 4 to use the run script or with a batch file

### DIFF
--- a/examples/4_run_model.ipynb
+++ b/examples/4_run_model.ipynb
@@ -12,32 +12,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates how to run and inspect a SFINCS model. The notebook does not contain the SFINCS code or executables to run the model with.\n",
-    "Below there is explained where and how to get the SFINCS executable "
+    "SFINCS is a compiled Fortran binary — Python cannot execute it directly.  \n",
+    "This notebook shows two ways to launch a simulation:\n",
+    "\n",
+    "| Method | Best for | Output log |\n",
+    "|--------|----------|------------|\n",
+    "| **Batch file** (`run.bat`) | Double-click from Explorer; share with colleagues who don't use Python | `sfincs.log` |\n",
+    "| **Python** (`run_sfincs`) | Running from within this notebook; streams live output into the cell | `sfincs_log.txt` |\n",
+    "\n",
+    "Both methods call the same executable and produce identical results.\n",
+    "\n",
+    "> **Prerequisites:** Download the SFINCS executable from https://download.deltares.nl/en/download/sfincs/"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All lines in this notebook which start with `!` are executed from the command line. Within jupyter (except for jupyter lab) the logging messages are shown after completion."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Inspecting the batch-file to run SFINCS"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "On Windows, you can run SFINCS by executing a batch-file.\n",
-    "We have already prepared this for an example model called *'sfincs_compound'*.\n",
-    "Let's now inspect this batch-file."
+    "---\n",
+    "## Settings"
    ]
   },
   {
@@ -46,10 +39,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fn = \"./sfincs_compound/run.bat\"\n",
-    "with open(fn, \"r\") as f:\n",
-    "    txt = f.read()\n",
-    "print(txt)"
+    "from pathlib import Path\n",
+    "\n",
+    "# ── Adjust these two paths ────────────────────────────────────────────────────\n",
+    "model_root = Path(\"./sfincs_compound\")  # folder containing sfincs.inp\n",
+    "sfincs_exe_dir = Path(\"../sfincs_exe\")  # folder containing sfincs.exe\n",
+    "# ─────────────────────────────────────────────────────────────────────────────\n",
+    "\n",
+    "sfincs_exe = sfincs_exe_dir / \"sfincs.exe\"  # full path — used by run_sfincs\n",
+    "\n",
+    "print(f\"Model folder  : {model_root.resolve()}\")\n",
+    "print(f\"Executable    : {sfincs_exe.resolve()}\")\n",
+    "print(f\"Exe found     : {sfincs_exe.exists()}\")"
    ]
   },
   {
@@ -57,32 +58,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Explanation of what is in the batch file:**\n",
+    "---\n",
+    "## Method 1 — Batch file\n",
     "\n",
-    "* 'call' means here that an executable has to be run.\n",
-    "* ..\\sfincs_exe\\ is the folder where the executable 'sfincs.exe' is located\n",
-    "* The '>sfincs_log.txt' means that the output should be written to a log-file called 'sfincs_log.txt'"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you don't have SFINCS yet, download SFINCS from here: https://download.deltares.nl/en/download/sfincs/\n",
+    "A batch file (`run.bat`) is a two-line Windows script: it sets one environment variable\n",
+    "and calls the SFINCS binary. No Python is needed at runtime — useful for sharing a simulation\n",
+    "with colleagues or scheduling automated runs.\n",
     "\n",
-    "Then open the file *'run.bat'* in any text editor, and add the folder of where you have saved the SFINCS executable *'sfincs.exe'*.\n",
+    "The recommended way to write it is via `SfincsModel.write_batch_file()`, which handles both\n",
+    "Windows (`run.bat`) and Linux/macOS (`run.sh`, with execute permissions set automatically).\n",
     "\n",
-    "e.g. to *\"c:\\SFINCS_download\\sfincs.exe\"*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "###  Open log file\n",
-    "\n",
-    "Let's see whether this log-file with information of SFINCS output information is already available"
+    "> **Path convention:** `SfincsModel` expects the **folder** containing the binary (`exe_path`),\n",
+    "> not the full path to the executable itself."
    ]
   },
   {
@@ -91,26 +78,69 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fn = \"./sfincs_compound/sfincs_log.txt\"\n",
-    "with open(fn, \"r\") as f:\n",
-    "    txt = f.read()\n",
-    "print(txt)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In case you get an error message, this means that the log-file is not available, and SFINCS has not run yet.\n",
+    "from hydromt_sfincs import SfincsModel\n",
     "\n",
-    "Let's now do this..."
+    "# Open the model read-only and pass the executable folder\n",
+    "sf = SfincsModel(\n",
+    "    root=model_root,\n",
+    "    mode=\"r\",\n",
+    "    exe_path=str(sfincs_exe_dir),  # folder — SfincsModel appends sfincs.exe internally\n",
+    ")\n",
+    "\n",
+    "bat_file = sf.write_batch_file()\n",
+    "print(f\"Launcher written : {bat_file}\")\n",
+    "print(f\"\\nContents:\\n{bat_file.read_text()}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Now let's try to run this batch-file"
+    "> **Alternative — write the batch file manually** (no model object needed):\n",
+    "> ```python\n",
+    "> bat_file = model_root / 'run.bat'\n",
+    "> bat_file.write_text(\n",
+    ">     f'set HDF5_USE_FILE_LOCKING=FALSE\\n\"{sfincs_exe}\"\\n',\n",
+    ">     encoding='ascii',\n",
+    "> )\n",
+    "> ```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Launching the batch file\n",
+    "\n",
+    "| Interface | Command |\n",
+    "|-----------|---------|\n",
+    "| **Windows Explorer** | Navigate to the model folder → double-click `run.bat` |\n",
+    "| **Command Prompt** | `cd <model_folder>` then `run.bat` |\n",
+    "| **PowerShell / VS Code terminal** | `cd <model_folder>` then `.\\run.bat` |\n",
+    "\n",
+    "A Command Prompt window opens and streams SFINCS output while it runs.\n",
+    "`sfincs.log` is written to the model folder on completion.\n",
+    "\n",
+    "> **HPC / network drive:** `HDF5_USE_FILE_LOCKING=FALSE` prevents NetCDF write errors\n",
+    "> caused by file-locking restrictions on some shared file systems."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Method 2 — Python (`run_sfincs`)\n",
+    "\n",
+    "`run_sfincs` from `hydromt_sfincs.run` launches the executable as a subprocess and:\n",
+    "\n",
+    "- streams output **live** into the notebook cell\n",
+    "- raises a `RuntimeError` immediately if the run fails (non-zero exit code)\n",
+    "- writes all captured output to `sfincs_log.txt` in the model folder\n",
+    "\n",
+    "> **Path convention:** `run_sfincs` expects the **full path** to the executable\n",
+    "> (`sfincs_exe_dir / 'sfincs.exe'`), unlike `SfincsModel` which takes the folder."
    ]
   },
   {
@@ -119,32 +149,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "from hydromt_sfincs.run import run_sfincs\n",
     "\n",
-    "run_path = \"./sfincs_compound\"\n",
-    "\n",
-    "cur_dir = os.getcwd()\n",
-    "\n",
-    "# uncomment to run sfincs\n",
-    "# os.chdir(run_path)\n",
-    "# os.system(\"run.bat\")\n",
-    "# os.chdir(cur_dir)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "* It should now take less than a minute or so for the SFINCS simulation to finish (not available on Binder)\n",
-    "* We can now have a look at the log-file"
+    "if sfincs_exe.exists():\n",
+    "    run_sfincs(\n",
+    "        model_root=model_root,\n",
+    "        sfincs_exe=sfincs_exe,  # full path to sfincs.exe\n",
+    "    )\n",
+    "else:\n",
+    "    print(f\"Skipping: executable not found at {sfincs_exe}\")\n",
+    "    print(\"Download from: https://download.deltares.nl/en/download/sfincs/\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Created log-file"
+    "---\n",
+    "## Check the run log\n",
+    "\n",
+    "The log location depends on how the model was launched:\n",
+    "\n",
+    "| Method | Log file |\n",
+    "|--------|----------|\n",
+    "| Batch file | `sfincs.log` (written by the SFINCS binary) |\n",
+    "| `run_sfincs` | `sfincs_log.txt` (captured stdout/stderr) |\n",
+    "\n",
+    "The last lines should contain `Simulation finished`."
    ]
   },
   {
@@ -153,33 +184,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fn = \"./sfincs_compound/sfincs_log.txt\"\n",
-    "with open(fn, \"r\") as f:\n",
-    "    txt = f.read()\n",
-    "print(txt)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we actually should have output!\n",
+    "# run_sfincs writes sfincs_log.txt; the SFINCS binary itself writes sfincs.log\n",
+    "log_file = model_root / \"sfincs_log.txt\"\n",
+    "if not log_file.exists():\n",
+    "    log_file = model_root / \"sfincs.log\"\n",
     "\n",
-    "You have run your first SFINCS model."
+    "if log_file.exists():\n",
+    "    lines = log_file.read_text(errors=\"replace\").splitlines()\n",
+    "    print(f\"Log: {log_file.name}  ({len(lines)} lines)\")\n",
+    "    print(\"\\n--- Last 20 lines ---\")\n",
+    "    print(\"\\n\".join(lines[-20:]))\n",
+    "else:\n",
+    "    print(\"No log file found — has the model run yet?\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Created netcdf output files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's now inspect what files there are situated in the folder of the model setup:"
+    "---\n",
+    "## Output files\n",
+    "\n",
+    "A successful SFINCS run produces two NetCDF files in the model folder:\n",
+    "\n",
+    "| File | Contents |\n",
+    "|------|----------|\n",
+    "| `sfincs_map.nc` | Gridded results: water levels (`zs`), max water level (`zsmax`), wave height (`hm0`) |\n",
+    "| `sfincs_his.nc` | Time series at observation points: water level, wave height, wave direction |"
    ]
   },
   {
@@ -188,12 +219,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = \"./sfincs_compound\"\n",
-    "\n",
-    "dir_list = os.listdir(path)\n",
-    "\n",
-    "# prints all files\n",
-    "print(dir_list)"
+    "for fn in [\"sfincs_map.nc\", \"sfincs_his.nc\"]:\n",
+    "    fp = model_root / fn\n",
+    "    if fp.exists():\n",
+    "        print(f\"  {fn}: {fp.stat().st_size / 1e6:.1f} MB\")\n",
+    "    else:\n",
+    "        print(f\"  {fn}: NOT FOUND\")"
    ]
   },
   {
@@ -201,30 +232,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see here the earlier inspected log-file *'sfincs_log.txt'*\n",
+    "---\n",
+    "## Next steps\n",
     "\n",
-    "Do you additionally see the files *'sfincs_map.nc'* and *'sfincs_his.nc'* ?\n",
+    "Continue to the postprocessing notebooks to visualise the results:\n",
     "\n",
-    "These are output files of SFINCS, containing the model results in the common NetCDF format."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Continue to postprocessing and visualization"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can now continue to the notebook(s):\n",
-    "\n",
-    "- [Example: Maximum water depth](5_plot_results_hmax.ipynb)\n",
-    "- [Example: Animation](6_make_results_animation.ipynb)"
+    "- [Maximum water depth](5_plot_results_hmax.ipynb)\n",
+    "- [Animation](6_make_results_animation.ipynb)"
    ]
   }
  ],
@@ -244,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We had added some new functionaliy to run a SFINCS model from Python (in run.py) or through a batch-file with SfincsModel.write_batch_file(). This is now also added in the notebook 4 where we show how to run a SFINCS model. So this simply is an imporvement on the existing documentation and examples.