### PR TITLE
write quadtree without refinement by default to quadtree outputs. Kee…

### DIFF
--- a/hydromt_sfincs/components/config/config_variables.py
+++ b/hydromt_sfincs/components/config/config_variables.py
@@ -841,10 +841,10 @@ class SfincsConfigVariables(BaseSettings):
         0, ge=0, le=1, description="Write dynamic bed level output (1: yes, 0: no)"
     )
     regular_output_on_mesh: int = Field(
-        0,
+        1,
         ge=0,
         le=1,
-        description="Write regular grid on quadtree mesh output (1: yes, 0: no)",
+        description="Write quadtree without refinement on quadtree mesh (1: yes) or regular grid (0: no)",
     )
     twet_threshold: float = Field(
         0.01, ge=0.0, description="Time-wet minimum depth threshold (m)"


### PR DESCRIPTION
…ping inputs/outputs similar format is easier in current python setup

## Issue addressed
Fixes #360 

## Explanation
With this new default value, the inputs and outputs are always of the same format, so the python code should always work. When users would like their quadtree output without refinements on a regular grid, it's conscious choice, so the user can also use xarray to read the outputs.


## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
