### PR TITLE
provide clear warning for when the netcdf meteo forcing is not coveri…

### DIFF
--- a/hydromt_sfincs/components/forcing/meteo.py
+++ b/hydromt_sfincs/components/forcing/meteo.py
@@ -237,18 +237,11 @@ class SfincsMeteo(ModelComponent):
         # Get the start and end time of the data
         time_start = data.indexes["time"][0].to_pydatetime()
         time_end = data.indexes["time"][-1].to_pydatetime()
-        if time_start > model_start:
-            raise ValueError(
-                f"{name} forcing starts after the model start time. "
-                f"Model starts at {model_start}, {name} starts at "
-                f"{time_start}."
-            )
-
-        if time_end < model_end:
+        if time_start > model_start or time_end < model_end:
             logger.warning(
-                f"{name} forcing does not cover the full model period. "
-                f"Model ends at {model_end}, {name} ends at "
-                f"{time_end}."
+                f"{name} forcing does not cover the full model period."
+                f"Model runs from {model_start} to {model_end}, {name} spans"
+                f"from {time_start} to {time_end}."
             )
 
         # TODO: don't we always want to reset the data when setting new data?

--- a/hydromt_sfincs/components/forcing/meteo.py
+++ b/hydromt_sfincs/components/forcing/meteo.py
@@ -8,7 +8,7 @@ import xarray as xr
 
 from hydromt import hydromt_step
 from hydromt.model.components import ModelComponent
-from hydromt.model.processes.meteo import da_to_timedelta
+from hydromt.model.processes.meteo import da_to_timedelta, precip
 
 from hydromt_sfincs import readers, utils, writers
 
@@ -231,6 +231,25 @@ class SfincsMeteo(ModelComponent):
             data = data.to_dataset()
         elif not isinstance(data, xr.Dataset):
             raise ValueError(f"cannot set data of type {type(data).__name__}")
+
+        # Check if the time coordinates of the data match the model
+        model_start, model_end = self.model.get_model_time()
+        # Get the start and end time of the data
+        time_start = data.indexes["time"][0].to_pydatetime()
+        time_end = data.indexes["time"][-1].to_pydatetime()
+        if time_start > model_start:
+            raise ValueError(
+                f"{name} forcing starts after the model start time. "
+                f"Model starts at {model_start}, {name} starts at "
+                f"{time_start}."
+            )
+
+        if time_end < model_end:
+            logger.warning(
+                f"{name} forcing does not cover the full model period. "
+                f"Model ends at {model_end}, {name} ends at "
+                f"{time_end}."
+            )
 
         # TODO: don't we always want to reset the data when setting new data?
         # that would mean that you can never have 1D and 2D data at the same time

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -101,11 +101,13 @@ def test_create_meteo_time_bounds(model_config, caplog):
     # get the forcing data from the data catalog
     ds = model_config.data_catalog.get_rasterdataset("era5_hourly_zarr")
 
-    # forcing starts too late -> should raise
+    # forcing starts too late -> should warn
     ds_late = ds.sel(time=slice("2010-02-06", None))
 
-    with pytest.raises(ValueError, match="starts after the model start time"):
+    with caplog.at_level(logging.WARNING):
         model_config.precipitation.create(precip=ds_late)
+
+    assert "forcing does not cover the full model period" in caplog.text
 
     # forcing covers tstart but ends before tstop -> should warn
     ds_short = ds.sel(time=slice("2010-02-01", "2010-02-06"))

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -1,5 +1,7 @@
-from os.path import abspath, dirname, join, isfile
 from datetime import datetime
+from os.path import abspath, dirname, join, isfile
+import logging
+import pytest
 
 from hydromt_sfincs.sfincs import SfincsModel
 
@@ -93,3 +95,22 @@ def test_create_meteo_latlon(tmp_dir):
         assert comp.data is not None
         assert comp.data.raster.dims == ("y", "x")
         assert comp.data.raster.crs == "EPSG:4326"
+
+
+def test_create_meteo_time_bounds(model_config, caplog):
+    # get the forcing data from the data catalog
+    ds = model_config.data_catalog.get_rasterdataset("era5_hourly_zarr")
+
+    # forcing starts too late -> should raise
+    ds_late = ds.sel(time=slice("2010-02-06", None))
+
+    with pytest.raises(ValueError, match="starts after the model start time"):
+        model_config.precipitation.create(precip=ds_late)
+
+    # forcing covers tstart but ends before tstop -> should warn
+    ds_short = ds.sel(time=slice("2010-02-01", "2010-02-06"))
+
+    with caplog.at_level(logging.WARNING):
+        model_config.precipitation.create(precip=ds_short)
+
+    assert "forcing does not cover the full model period" in caplog.text


### PR DESCRIPTION
…ng the full model period --> especially tstart causes the kernel to crash

## Issue addressed
Fixes #322

## Explanation
Now we get a value error when the data that we finally set to the model does not cover the start, and a warning when the timeseries are too short.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [x] Updated changelog.rst if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
