### PR TITLE
make sure that only gridded variables that actually exist are written to file

### DIFF
--- a/hydromt_sfincs/__init__.py
+++ b/hydromt_sfincs/__init__.py
@@ -2,7 +2,7 @@
 
 from os.path import abspath, dirname, join
 
-__version__ = "2.0.0-rc3"
+__version__ = "2.0.0-rc4dev"
 
 DATADIR = join(dirname(abspath(__file__)), "data")
 

--- a/hydromt_sfincs/components/grid/regulargrid.py
+++ b/hydromt_sfincs/components/grid/regulargrid.py
@@ -252,12 +252,21 @@ class SfincsGrid(GridComponent):
             # Write index file
             self.write_ind(ind_fn=abs_file_path, mask=mask)
 
-            if data_vars is None:  # write all maps
+            if data_vars is None:  # write all maps that are present in the dataset
                 data_vars = [v for v in _MAPS if v in ds_out]
+            elif isinstance(data_vars, list):
+                # check which data_vars are not defined, remove them, and provide warning
+                for name in data_vars:
+                    if name not in ds_out:
+                        logger.warning(f"{name} not found in data, skipping.")
+                        data_vars.remove(name)
             elif isinstance(data_vars, str):
+                # check if data_vars is defined
+                if data_vars not in ds_out:
+                    raise ValueError(f"{data_vars} not found in data.")
                 data_vars = list(data_vars)
-                # always rewrite the mask
-                data_vars.append("mask") if "mask" not in data_vars else data_vars
+            # always rewrite the mask
+            data_vars.append("mask") if "mask" not in data_vars else data_vars
 
             logger.debug(f"Write binary map files: {data_vars}.")
             for name in data_vars:

--- a/hydromt_sfincs/components/quadtree/quadtree.py
+++ b/hydromt_sfincs/components/quadtree/quadtree.py
@@ -282,9 +282,7 @@ class SfincsQuadtreeGrid(MeshComponent):
             # infiltration uses a non-standard config key ("infiltration_file");
             # other variables follow the default "{var}file" pattern.
             key = _QT_MAPS.get(var) or f"{var}file"
-            abs_file_path = self.model.config.get_set_file_variable(
-                key, default=f"{var}.nc"
-            )
+            abs_file_path = self.model.config.get(key, abs_path=True)
             if abs_file_path is not None:
                 abs_file_path.parent.mkdir(parents=True, exist_ok=True)
                 variables.append({"variable": var, "file_name": abs_file_path})


### PR DESCRIPTION
In #405, I think I broke the reading/writing of especially quadtree grids. By using get_set_file_variable, we also added filenames of variables that were never created. Therefore, in quadtree.py, we reverted this to config.get().

Will raise a new issue where we can think about the reading/writing of quadtree, because the separation into multiple files is not always as convenient, and the code is a bit of a mess ...