### PR TITLE
Fix SnapWave quadtree mask model kwarg handling

### DIFF
--- a/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
+++ b/hydromt_sfincs/components/quadtree/snapwave_quadtree_mask.py
@@ -41,9 +41,15 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
         mask = self.data["snapwave_mask"]
         return (mask == 2).any().item()
 
+    @staticmethod
+    def _validate_model(model: str) -> None:
+        if model != "snapwave":
+            raise ValueError("SnapWaveQuadtreeMask only supports model='snapwave'.")
+
     @hydromt_step
     def create(
         self,
+        model: str = "snapwave",
         zmin: float = None,
         zmax: float = None,
         include_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
@@ -86,8 +92,9 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
         * `create_boundary` method to setup boundary cells of a specific type
 
         """
+        self._validate_model(model)
         super().create(
-            model="snapwave",
+            model=model,
             zmin=zmin,
             zmax=zmax,
             include_polygon=include_polygon,
@@ -108,6 +115,7 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
     @hydromt_step
     def create_active(
         self,
+        model: str = "snapwave",
         zmin: float = None,
         zmax: float = None,
         include_polygon: Union[str, Path, gpd.GeoDataFrame] = None,
@@ -152,9 +160,10 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
         copy_sfincsmask: bool, optional
             If True, ccopy the SFINCS mask to the SnapWave mask.
         """
+        self._validate_model(model)
 
         super().create_active(
-            model="snapwave",
+            model=model,
             zmin=zmin,
             zmax=zmax,
             include_polygon=include_polygon,
@@ -171,6 +180,7 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
     @hydromt_step
     def create_boundary(
         self,
+        model: str = "snapwave",
         btype: str = "waves",
         zmin: float = None,
         zmax: float = None,
@@ -222,8 +232,9 @@ class SnapWaveQuadtreeMask(SfincsQuadtreeMask):
             The connectivity used to detect the model edge, if 4 only horizontal and vertical
             connections are used, if 8 (default) also diagonal connections.
         """
+        self._validate_model(model)
         super().create_boundary(
-            model="snapwave",
+            model=model,
             btype=btype,
             zmin=zmin,
             zmax=zmax,

--- a/tests/test_snapwave_boundary.py
+++ b/tests/test_snapwave_boundary.py
@@ -329,6 +329,16 @@ def test_create_from_grid(quadtree_model_config):
     assert not mod.snapwave_boundary_conditions.data.equals(da_org)
 
 
+def test_quadtree_snapwave_mask_create_active_model_kwarg(quadtree_model_config):
+    mod = quadtree_model_config
+
+    mod.quadtree_snapwave_mask.create_active(model="snapwave", copy_sfincsmask=True)
+    assert "snapwave_mask" in mod.quadtree_grid.data
+
+    with pytest.raises(ValueError):
+        mod.quadtree_snapwave_mask.create_active(model="sfincs")
+
+
 def test_delete_clear(quadtree_model_config):
     """Test deleting a wave point from the model."""
     # assign the quadtree_model_config to a local variable for easier access


### PR DESCRIPTION
## Summary
- Align SnapWaveQuadtreeMask overridden method signatures with model kwarg forwarding
- Validate that only model='snapwave' is accepted in SnapWave-specific quadtree mask methods
- Add regression coverage for quadtree_snapwave_mask.create_active(model=...) calls

## Validation
- Ran targeted snapwave boundary tests (2 passed)